### PR TITLE
Update FFmpeg to v7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -392,6 +392,7 @@ RUN --mount=type=cache,target=/root/.cache `
 FROM layer-45 AS layer-50-x265
 
 RUN --mount=type=cache,target=/root/.cache `
+	--mount=type=bind,source=patches/50-x265,target="${PREFIX}/patches" `
 	--mount=type=bind,source=stages/50-x265.sh,target=/srv/stage.sh `
 	/srv/build.sh
 

--- a/patches/50-x265/aarch64-optimisations.patch
+++ b/patches/50-x265/aarch64-optimisations.patch
@@ -1,138 +1,3 @@
-diff --git a/build/README.txt b/build/README.txt
-index 6346eb041..af4abd21c 100644
---- a/build/README.txt
-+++ b/build/README.txt
-@@ -94,22 +94,23 @@ found, the version will be "unknown".
- 
- = Build Instructions for cross-compilation for Arm AArch64 Targets=
- 
--When the target platform is based on Arm AArch64 architecture, the x265 can be
--built in x86 platforms. However, the CMAKE_C_COMPILER and CMAKE_CXX_COMPILER
--enviroment variables should be set to point to the cross compilers of the
--appropriate gcc. For example:
-+Cross compilation of x265 for AArch64 targets is possible on x86 platforms by
-+passing a toolchain file when running CMake to configure the project:
- 
--1. export CMAKE_C_COMPILER=aarch64-unknown-linux-gnu-gcc
--2. export CMAKE_CXX_COMPILER=aarch64-unknown-linux-gnu-g++
-+* cmake -DCMAKE_TOOLCHAIN_FILE=<path-to-toolchain-file>
- 
--The default ones are aarch64-linux-gnu-gcc and aarch64-linux-gnu-g++.
--Then, the normal building process can be followed.
-+Toolchain files for AArch64 cross-compilation exist in the /build directory.
-+These specify a default cross-compiler to use; however this can be overridden
-+by setting the CMAKE_C_COMPILER and CMAKE_CXX_COMPILER CMake variables when
-+running CMake to configure the project. For example:
- 
--Moreover, if the target platform supports SVE or SVE2 instruction set, the
--CROSS_COMPILE_SVE or CROSS_COMPILE_SVE2 environment variables should be set
--to true, respectively. For example:
-+* cmake -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++
- 
--1. export CROSS_COMPILE_SVE2=true
--2. export CROSS_COMPILE_SVE=true
-+Moreover, if the target platform supports SVE or SVE2, CROSS_COMPILE_SVE or
-+CROSS_COMPILE_SVE2 CMake options should be set to ON, respectively.
-+For example, when running CMake to configure the project:
- 
--Then, the normal building process can be followed.
-+1. cmake -DCROSS_COMPILE_SVE=ON  <other configuration options...>
-+2. cmake -DCROSS_COMPILE_SVE2=ON <other configuration options...>
-+
-+Then, the normal build process can be followed.
-diff --git a/build/aarch64-darwin/crosscompile.cmake b/build/aarch64-darwin/crosscompile.cmake
-index d933daaa2..6037d5ed6 100644
---- a/build/aarch64-darwin/crosscompile.cmake
-+++ b/build/aarch64-darwin/crosscompile.cmake
-@@ -7,17 +7,14 @@ set(CROSS_COMPILE_ARM64 1)
- set(CMAKE_SYSTEM_NAME Darwin)
- set(CMAKE_SYSTEM_PROCESSOR aarch64)
- 
--# specify the cross compiler
--set(CMAKE_C_COMPILER gcc-12)
--set(CMAKE_CXX_COMPILER g++-12)
-+# specify the cross compiler (giving precedence to user-supplied CC/CXX)
-+if(NOT DEFINED CMAKE_C_COMPILER)
-+    set(CMAKE_C_COMPILER gcc)
-+endif()
-+if(NOT DEFINED CMAKE_CXX_COMPILER)
-+    set(CMAKE_CXX_COMPILER g++)
-+endif()
- 
- # specify the target environment
- SET(CMAKE_FIND_ROOT_PATH  /opt/homebrew/bin/)
- 
--# specify whether SVE/SVE2 is supported by the target platform
--if(DEFINED ENV{CROSS_COMPILE_SVE2})
--    set(CROSS_COMPILE_SVE2 1)
--elseif(DEFINED ENV{CROSS_COMPILE_SVE})
--    set(CROSS_COMPILE_SVE 1)
--endif()
--
-diff --git a/build/aarch64-linux-clang/crosscompile.cmake b/build/aarch64-linux-clang/crosscompile.cmake
-new file mode 100644
-index 000000000..41c76e166
---- /dev/null
-+++ b/build/aarch64-linux-clang/crosscompile.cmake
-@@ -0,0 +1,25 @@
-+# CMake toolchain file for cross compiling x265 for AArch64, using Clang.
-+
-+set(CROSS_COMPILE_ARM64 1)
-+set(CMAKE_SYSTEM_NAME Linux)
-+set(CMAKE_SYSTEM_PROCESSOR aarch64)
-+
-+set(TARGET_TRIPLE aarch64-linux-gnu)
-+
-+# specify the cross compiler (giving precedence to user-supplied CC/CXX)
-+if(NOT DEFINED CMAKE_C_COMPILER)
-+    set(CMAKE_C_COMPILER clang)
-+endif()
-+if(NOT DEFINED CMAKE_CXX_COMPILER)
-+    set(CMAKE_CXX_COMPILER clang++)
-+endif()
-+
-+# specify compiler target
-+set(CMAKE_C_COMPILER_TARGET ${TARGET_TRIPLE})
-+set(CMAKE_CXX_COMPILER_TARGET ${TARGET_TRIPLE})
-+
-+# specify assembler target
-+list(APPEND ASM_FLAGS "--target=${TARGET_TRIPLE}")
-+
-+# specify the target environment
-+SET(CMAKE_FIND_ROOT_PATH /usr/aarch64-linux-gnu)
-diff --git a/build/aarch64-linux/crosscompile.cmake b/build/aarch64-linux/crosscompile.cmake
-index 8cfe3243d..caf26af77 100644
---- a/build/aarch64-linux/crosscompile.cmake
-+++ b/build/aarch64-linux/crosscompile.cmake
-@@ -7,25 +7,14 @@ set(CROSS_COMPILE_ARM64 1)
- set(CMAKE_SYSTEM_NAME Linux)
- set(CMAKE_SYSTEM_PROCESSOR aarch64)
- 
--# specify the cross compiler
--if(DEFINED ENV{CMAKE_C_COMPILER})
--    set(CMAKE_C_COMPILER $ENV{CMAKE_C_COMPILER})
--else()
-+# specify the cross compiler (giving precedence to user-supplied CC/CXX)
-+if(NOT DEFINED CMAKE_C_COMPILER)
-     set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
- endif()
--if(DEFINED ENV{CMAKE_CXX_COMPILER})
--    set(CMAKE_CXX_COMPILER $ENV{CMAKE_CXX_COMPILER})
--else()
-+if(NOT DEFINED CMAKE_CXX_COMPILER)
-     set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
- endif()
- 
- # specify the target environment
- SET(CMAKE_FIND_ROOT_PATH  /usr/aarch64-linux-gnu)
- 
--# specify whether SVE/SVE2 is supported by the target platform
--if(DEFINED ENV{CROSS_COMPILE_SVE2})
--    set(CROSS_COMPILE_SVE2 1)
--elseif(DEFINED ENV{CROSS_COMPILE_SVE})
--    set(CROSS_COMPILE_SVE 1)
--endif()
--
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
 index ab5ddfeb7..bed98bb37 100755
 --- a/source/CMakeLists.txt
@@ -143,7 +8,7 @@ index ab5ddfeb7..bed98bb37 100755
  include(CheckCXXCompilerFlag)
 +include(CheckCSourceCompiles)
 +include(CheckCXXSourceCompiles)
- 
+
  option(FPROFILE_GENERATE "Compile executable to generate usage data" OFF)
  option(FPROFILE_USE "Compile executable using generated usage data" OFF)
 @@ -88,6 +90,10 @@ elseif(ARM64MATCH GREATER "-1")
@@ -184,7 +49,7 @@ index ab5ddfeb7..bed98bb37 100755
 @@ -281,6 +294,28 @@ if(GCC)
          else()
              set(ARM_ARGS -fPIC -flax-vector-conversions)
-         endif()        
+         endif()
 +        if(CPU_HAS_SVE)
 +            set(SVE_HEADER_TEST "
 +#ifndef __ARM_NEON_SVE_BRIDGE
@@ -214,7 +79,7 @@ index ab5ddfeb7..bed98bb37 100755
      if (CC_HAS_FAST_MATH)
          add_definitions(-ffast-math)
      endif()
--    check_cxx_compiler_flag(-mstackrealign CC_HAS_STACK_REALIGN) 
+-    check_cxx_compiler_flag(-mstackrealign CC_HAS_STACK_REALIGN)
 -    if (CC_HAS_STACK_REALIGN)
 -        add_definitions(-mstackrealign)
 +    if (NOT (ARM64 OR CROSS_COMPILE_ARM64))
@@ -232,12 +97,12 @@ index 184b94127..40c932966 100644
 @@ -103,7 +103,8 @@ if(ENABLE_ASSEMBLY AND (ARM64 OR CROSS_COMPILE_ARM64))
          add_definitions(-DAUTO_VECTORIZE=1)
      endif()
- 
+
 -    set(C_SRCS asm-primitives.cpp pixel-prim.h pixel-prim.cpp filter-prim.h filter-prim.cpp dct-prim.h dct-prim.cpp loopfilter-prim.cpp loopfilter-prim.h intrapred-prim.cpp arm64-utils.cpp arm64-utils.h fun-decls.h)
 +    set(C_SRCS_NEON asm-primitives.cpp pixel-prim.h pixel-prim.cpp filter-prim.h filter-prim.cpp dct-prim.h dct-prim.cpp loopfilter-prim.cpp loopfilter-prim.h intrapred-prim.cpp arm64-utils.cpp arm64-utils.h fun-decls.h sao-prim.cpp)
 +    set(C_SRCS_SVE sao-prim-sve.cpp)
      enable_language(ASM)
- 
+
      # add ARM assembly/intrinsic files here
 @@ -115,9 +116,16 @@ if(ENABLE_ASSEMBLY AND (ARM64 OR CROSS_COMPILE_ARM64))
      set(ARM_ASMS "${A_SRCS}" CACHE INTERNAL "ARM Assembly Sources")
@@ -256,7 +121,7 @@ index 184b94127..40c932966 100644
 +
      source_group(Assembly FILES ${ASM_PRIMITIVES})
  endif(ENABLE_ASSEMBLY AND (ARM64 OR CROSS_COMPILE_ARM64))
- 
+
 diff --git a/source/common/aarch64/asm-primitives.cpp b/source/common/aarch64/asm-primitives.cpp
 index 8c46bfd21..bab34a493 100644
 --- a/source/common/aarch64/asm-primitives.cpp
@@ -266,11 +131,11 @@ index 8c46bfd21..bab34a493 100644
  #include "loopfilter-prim.h"
  #include "intrapred-prim.h"
 +#include "sao-prim.h"
- 
+
  namespace X265_NS
  {
 @@ -708,12 +709,6 @@ void interp_8tap_hv_pp_cpu(const pixel *src, intptr_t srcStride, pixel *dst, int
- 
+
  void setupNeonPrimitives(EncoderPrimitives &p)
  {
 -    setupPixelPrimitives_neon(p);
@@ -314,7 +179,7 @@ index 8c46bfd21..bab34a493 100644
      CHROMA_422_PU_NEON_FILTER_PIXEL_TO_SHORT(p2s[ALIGNED]);
 @@ -1961,4 +1940,24 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
  #endif
- 
+
  }
 +
 +void setupIntrinsicPrimitives(EncoderPrimitives &p, int cpuMask)
@@ -342,9 +207,9 @@ index ce0668103..742978631 100644
 --- a/source/common/aarch64/asm.S
 +++ b/source/common/aarch64/asm.S
 @@ -72,6 +72,16 @@
- 
+
  #define PFX_C(name)        JOIN(JOIN(JOIN(EXTERN_ASM, X265_NS), _), name)
- 
+
 +// Alignment of stack arguments of size less than 8 bytes.
 +#ifdef __APPLE__
 +#define STACK_ARG_ALIGNMENT 4
@@ -361,7 +226,7 @@ index ce0668103..742978631 100644
 @@ -184,4 +194,4 @@ ELF     .size   \name, . - \name
      vtrn            \t3, \t4, \s3, \s4
  .endm
- 
+
 -#endif
 \ No newline at end of file
 +#endif
@@ -652,7 +517,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_csp32
      ret
  endfunc
- 
+
 @@ -108,7 +108,7 @@ function PFX(blockcopy_sp_64x64_neon)
      sub             x3, x3, #64
      movrel          x11, xtn_xtn2_table
@@ -670,7 +535,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_csp64
      ret
  endfunc
- 
+
 @@ -168,7 +168,7 @@ endfunc
  function PFX(blockcopy_ps_32x32_neon)
      lsl             x1, x1, #1
@@ -688,7 +553,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cps32
      ret
  endfunc
- 
+
 @@ -192,7 +192,7 @@ function PFX(blockcopy_ps_64x64_neon)
      lsl             x1, x1, #1
      sub             x1, x1, #64
@@ -706,7 +571,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cps64
      ret
  endfunc
- 
+
 @@ -252,13 +252,13 @@ function PFX(blockcopy_ss_32x32_neon)
      lsl             x1, x1, #1
      lsl             x3, x3, #1
@@ -722,7 +587,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_css32
      ret
  endfunc
- 
+
 @@ -268,7 +268,7 @@ function PFX(blockcopy_ss_64x64_neon)
      lsl             x3, x3, #1
      sub             x3, x3, #64
@@ -740,7 +605,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_css64
      ret
  endfunc
- 
+
 @@ -321,13 +321,13 @@ function PFX(blockcopy_ss_32x64_neon)
      lsl             x1, x1, #1
      lsl             x3, x3, #1
@@ -756,7 +621,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_css32x64
      ret
  endfunc
- 
+
 @@ -376,7 +376,7 @@ endfunc
  function PFX(blockcopy_ps_32x64_neon)
      lsl             x1, x1, #1
@@ -774,7 +639,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cps32x64
      ret
  endfunc
- 
+
 @@ -443,7 +443,7 @@ function PFX(blockcopy_sp_32x64_neon)
      lsl             x3, x3, #1
      movrel          x11, xtn_xtn2_table
@@ -792,9 +657,9 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_csp32x64
      ret
  endfunc
- 
+
 @@ -595,13 +595,13 @@ blockcopy_pp_8xN_neon 32
- 
+
  function PFX(blockcopy_pp_8x64_neon)
      mov             w12, #4
 -.loop_pp_8x64:
@@ -808,7 +673,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_pp_8x64
      ret
  endfunc
- 
+
 @@ -623,13 +623,13 @@ blockcopy_pp_16xN_neon 16
  .macro blockcopy_pp_16xN1_neon h
  function PFX(blockcopy_pp_16x\h\()_neon)
@@ -841,7 +706,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_pp_12x32
      ret
  endfunc
- 
+
  function PFX(blockcopy_pp_24x32_neon)
      mov             w12, #4
 -.loop_24x32:
@@ -855,7 +720,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_24x32
      ret
  endfunc
- 
+
  function PFX(blockcopy_pp_24x64_neon)
      mov             w12, #4
 -.loop_24x64:
@@ -869,7 +734,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_24x64
      ret
  endfunc
- 
+
 @@ -697,13 +697,13 @@ endfunc
  .macro blockcopy_pp_32xN_neon h
  function PFX(blockcopy_pp_32x\h\()_neon)
@@ -887,7 +752,7 @@ index 495ee7ea2..1ad371c57 100644
  endfunc
  .endm
 @@ -716,26 +716,26 @@ blockcopy_pp_32xN_neon 48
- 
+
  function PFX(blockcopy_pp_48x64_neon)
      mov             w12, #8
 -.loop_48x64:
@@ -901,7 +766,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_48x64
      ret
  endfunc
- 
+
  .macro blockcopy_pp_64xN_neon h
  function PFX(blockcopy_pp_64x\h\()_neon)
      mov             w12, #\h / 4
@@ -928,7 +793,7 @@ index 495ee7ea2..1ad371c57 100644
      add             v18.16b, v18.16b, v0.16b
 -    cbnz            w12, .loop_count_nonzero_32
 +    cbnz            w12, .Loop_count_nonzero_32
- 
+
      uaddlv          s0, v18.8h
      fmov            w0, s0
 @@ -994,7 +994,7 @@ endfunc
@@ -948,7 +813,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy2Dto1D_shl_16
      ret
  endfunc
- 
+
  function PFX(cpy2Dto1D_shl_32x32_neon)
      cpy2Dto1D_shl_start
      mov             w12, #16
@@ -965,7 +830,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy2Dto1D_shl_32
      ret
  endfunc
- 
+
 @@ -1027,7 +1027,7 @@ function PFX(cpy2Dto1D_shl_64x64_neon)
      cpy2Dto1D_shl_start
      mov             w12, #32
@@ -983,7 +848,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy2Dto1D_shl_64
      ret
  endfunc
- 
+
 @@ -1079,7 +1079,7 @@ endfunc
  function PFX(cpy2Dto1D_shr_16x16_neon)
      cpy2Dto1D_shr_start
@@ -1001,7 +866,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy2Dto1D_shr_16
      ret
  endfunc
- 
+
  function PFX(cpy2Dto1D_shr_32x32_neon)
      cpy2Dto1D_shr_start
      mov             w12, #16
@@ -1018,7 +883,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy2Dto1D_shr_32
      ret
  endfunc
- 
+
 @@ -1147,7 +1147,7 @@ endfunc
  function PFX(cpy1Dto2D_shl_16x16_neon)
      cpy1Dto2D_shl_start
@@ -1036,7 +901,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy1Dto2D_shl_16
      ret
  endfunc
- 
+
  function PFX(cpy1Dto2D_shl_32x32_neon)
      cpy1Dto2D_shl_start
      mov             w12, #16
@@ -1053,7 +918,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy1Dto2D_shl_32
      ret
  endfunc
- 
+
 @@ -1180,7 +1180,7 @@ function PFX(cpy1Dto2D_shl_64x64_neon)
      cpy1Dto2D_shl_start
      mov             w12, #32
@@ -1071,7 +936,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy1Dto2D_shl_64
      ret
  endfunc
- 
+
 @@ -1231,7 +1231,7 @@ endfunc
  function PFX(cpy1Dto2D_shr_16x16_neon)
      cpy1Dto2D_shr_start
@@ -1089,7 +954,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy1Dto2D_shr_16
      ret
  endfunc
- 
+
  function PFX(cpy1Dto2D_shr_32x32_neon)
      cpy1Dto2D_shr_start
      mov             w12, #16
@@ -1106,7 +971,7 @@ index 495ee7ea2..1ad371c57 100644
 +    cbnz            w12, .Loop_cpy1Dto2D_shr_32
      ret
  endfunc
- 
+
 @@ -1270,7 +1270,7 @@ function PFX(cpy1Dto2D_shr_64x64_neon)
      cpy1Dto2D_shr_start
      mov             w12, #32
@@ -1130,11 +995,11 @@ index 1a1f3b489..ec17deda2 100644
 +++ b/source/common/aarch64/fun-decls.h
 @@ -155,69 +155,69 @@ DECLS(sve);
  DECLS(sve2);
- 
- 
+
+
 -void x265_pixel_planecopy_cp_neon(const uint8_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int width, int height, int shift);
 +void PFX(pixel_planecopy_cp_neon(const uint8_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int width, int height, int shift));
- 
+
 -uint64_t x265_pixel_var_8x8_neon(const pixel* pix, intptr_t stride);
 -uint64_t x265_pixel_var_16x16_neon(const pixel* pix, intptr_t stride);
 -uint64_t x265_pixel_var_32x32_neon(const pixel* pix, intptr_t stride);
@@ -1143,7 +1008,7 @@ index 1a1f3b489..ec17deda2 100644
 +uint64_t PFX(pixel_var_16x16_neon(const pixel* pix, intptr_t stride));
 +uint64_t PFX(pixel_var_32x32_neon(const pixel* pix, intptr_t stride));
 +uint64_t PFX(pixel_var_64x64_neon(const pixel* pix, intptr_t stride));
- 
+
 -void x265_getResidual4_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
 -void x265_getResidual8_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
 -void x265_getResidual16_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
@@ -1152,12 +1017,12 @@ index 1a1f3b489..ec17deda2 100644
 +void PFX(getResidual8_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
 +void PFX(getResidual16_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
 +void PFX(getResidual32_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
- 
+
 -void x265_scale1D_128to64_neon(pixel *dst, const pixel *src);
 -void x265_scale2D_64to32_neon(pixel* dst, const pixel* src, intptr_t stride);
 +void PFX(scale1D_128to64_neon(pixel *dst, const pixel *src));
 +void PFX(scale2D_64to32_neon(pixel* dst, const pixel* src, intptr_t stride));
- 
+
 -int x265_pixel_satd_4x4_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
 -int x265_pixel_satd_4x8_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
 -int x265_pixel_satd_4x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
@@ -1222,7 +1087,7 @@ index 1a1f3b489..ec17deda2 100644
 +int PFX(pixel_satd_64x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
 +int PFX(pixel_satd_64x48_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
 +int PFX(pixel_satd_64x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
- 
+
 -int x265_pixel_sa8d_8x8_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
 -int x265_pixel_sa8d_8x16_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
 -int x265_pixel_sa8d_16x16_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
@@ -1237,24 +1102,24 @@ index 1a1f3b489..ec17deda2 100644
 +int PFX(pixel_sa8d_32x32_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
 +int PFX(pixel_sa8d_32x64_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
 +int PFX(pixel_sa8d_64x64_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
- 
+
  uint32_t PFX(quant_neon)(const int16_t* coef, const int32_t* quantCoeff, int32_t* deltaU, int16_t* qCoef, int qBits, int add, int numCoeff);
  uint32_t PFX(nquant_neon)(const int16_t* coef, const int32_t* quantCoeff, int16_t* qCoef, int qBits, int add, int numCoeff);
- 
+
 -void x265_dequant_scaling_neon(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift);
 -void x265_dequant_normal_neon(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift);
 +void PFX(dequant_scaling_neon(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift));
 +void PFX(dequant_normal_neon(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift));
- 
+
 -void x265_ssim_4x4x2_core_neon(const pixel* pix1, intptr_t stride1, const pixel* pix2, intptr_t stride2, int sums[2][4]);
 +void PFX(ssim_4x4x2_core_neon(const pixel* pix1, intptr_t stride1, const pixel* pix2, intptr_t stride2, int sums[2][4]));
- 
+
  int PFX(psyCost_4x4_neon)(const pixel* source, intptr_t sstride, const pixel* recon, intptr_t rstride);
  int PFX(psyCost_8x8_neon)(const pixel* source, intptr_t sstride, const pixel* recon, intptr_t rstride);
 @@ -226,30 +226,30 @@ void PFX(weight_sp_neon)(const int16_t* src, pixel* dst, intptr_t srcStride, int
  int PFX(scanPosLast_neon)(const uint16_t *scan, const coeff_t *coeff, uint16_t *coeffSign, uint16_t *coeffFlag, uint8_t *coeffNum, int numSig, const uint16_t* scanCG4x4, const int trSize);
  uint32_t PFX(costCoeffNxN_neon)(const uint16_t *scan, const coeff_t *coeff, intptr_t trSize, uint16_t *absCoeff, const uint8_t *tabSigCtx, uint32_t scanFlagMask, uint8_t *baseCtx, int offset, int scanPosSigOff, int subPosBase);
- 
+
 -uint64_t x265_pixel_var_8x8_sve2(const pixel* pix, intptr_t stride);
 -uint64_t x265_pixel_var_16x16_sve2(const pixel* pix, intptr_t stride);
 -uint64_t x265_pixel_var_32x32_sve2(const pixel* pix, intptr_t stride);
@@ -1263,17 +1128,17 @@ index 1a1f3b489..ec17deda2 100644
 +uint64_t PFX(pixel_var_16x16_sve2(const pixel* pix, intptr_t stride));
 +uint64_t PFX(pixel_var_32x32_sve2(const pixel* pix, intptr_t stride));
 +uint64_t PFX(pixel_var_64x64_sve2(const pixel* pix, intptr_t stride));
- 
+
 -void x265_getResidual16_sve2(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
 -void x265_getResidual32_sve2(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
 +void PFX(getResidual16_sve2(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
 +void PFX(getResidual32_sve2(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
- 
+
 -void x265_scale1D_128to64_sve2(pixel *dst, const pixel *src);
 -void x265_scale2D_64to32_sve2(pixel* dst, const pixel* src, intptr_t stride);
 +void PFX(scale1D_128to64_sve2(pixel *dst, const pixel *src));
 +void PFX(scale2D_64to32_sve2(pixel* dst, const pixel* src, intptr_t stride));
- 
+
 -int x265_pixel_satd_4x4_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
 -int x265_pixel_satd_8x4_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
 -int x265_pixel_satd_8x12_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
@@ -1286,17 +1151,17 @@ index 1a1f3b489..ec17deda2 100644
 +int PFX(pixel_satd_32x16_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
 +int PFX(pixel_satd_32x32_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
 +int PFX(pixel_satd_64x48_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
- 
+
  uint32_t PFX(quant_sve)(const int16_t* coef, const int32_t* quantCoeff, int32_t* deltaU, int16_t* qCoef, int qBits, int add, int numCoeff);
- 
+
 -void x265_dequant_scaling_sve2(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift);
 -void x265_dequant_normal_sve2(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift);
 +void PFX(dequant_scaling_sve2(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift));
 +void PFX(dequant_normal_sve2(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift));
- 
+
 -void x265_ssim_4x4x2_core_sve2(const pixel* pix1, intptr_t stride1, const pixel* pix2, intptr_t stride2, int sums[2][4]);
 +void PFX(ssim_4x4x2_core_sve2(const pixel* pix1, intptr_t stride1, const pixel* pix2, intptr_t stride2, int sums[2][4]));
- 
+
  int PFX(psyCost_8x8_sve2)(const pixel* source, intptr_t sstride, const pixel* recon, intptr_t rstride);
  void PFX(weight_sp_sve2)(const int16_t* src, pixel* dst, intptr_t srcStride, intptr_t dstStride, int width, int height, int w0, int round, int shift, int offset);
 diff --git a/source/common/aarch64/ipfilter-common.S b/source/common/aarch64/ipfilter-common.S
@@ -1329,7 +1194,7 @@ index b7c61ee64..a08c3c165 100644
 +    cbnz            x5, .Loop_luma_vpp_\v\()_\w\()x\h
      ret
  .endm
- 
+
 @@ -854,10 +854,10 @@
      mov             w12, #8192
      dup             v31.8h, w12
@@ -1356,7 +1221,7 @@ index b7c61ee64..a08c3c165 100644
 +    cbnz            x5, .Loop_ps_\v\()_\w\()x\h
      ret
  .endm
- 
+
 @@ -914,10 +914,10 @@
      mov             x12, #\w
      lsl             x12, x12, #1
@@ -1383,7 +1248,7 @@ index b7c61ee64..a08c3c165 100644
 +    cbnz            x5, .Loop_luma_vsp_\v\()_\w\()x\h
      ret
  .endm
- 
+
 @@ -957,10 +957,10 @@
      mov             x12, #\w
      lsl             x12, x12, #1
@@ -1410,7 +1275,7 @@ index b7c61ee64..a08c3c165 100644
 +    cbnz            x5, .Loop_luma_vss_\v\()_\w\()x\h
      ret
  .endm
- 
+
 @@ -1013,11 +1013,11 @@
  .endr
      ret
@@ -1506,7 +1371,7 @@ index b7c61ee64..a08c3c165 100644
 +    cbnz            x5, .Loop_chroma_vpp_\v\()_\w\()x\h
      ret
  .endm
- 
+
 @@ -1152,10 +1152,10 @@
      lsl             x3, x3, #1
      sub             x0, x0, x1
@@ -1526,7 +1391,7 @@ index b7c61ee64..a08c3c165 100644
      cmp             x9, #\w
 -    blt             .loop_vps_w8_\v\()_\w\()x\h
 +    blt             .Loop_vps_w8_\v\()_\w\()x\h
- 
+
      add             x0, x0, x1
      add             x2, x2, x3
      sub             x5, x5, #1
@@ -1534,7 +1399,7 @@ index b7c61ee64..a08c3c165 100644
 +    cbnz            x5, .Loop_vps_\v\()_\w\()x\h
      ret
  .endm
- 
+
 @@ -1200,10 +1200,10 @@
      mov             x12, #\w
      lsl             x12, x12, #1
@@ -1561,7 +1426,7 @@ index b7c61ee64..a08c3c165 100644
 +    cbnz            x5, .Loop_vsp_\v\()_\w\()x\h
      ret
  .endm
- 
+
 @@ -1239,7 +1239,7 @@
      mov             x12, #\w
      lsl             x12, x12, #1
@@ -1594,7 +1459,7 @@ index b7c61ee64..a08c3c165 100644
 +    cbnz            x5, .Loop_vss_\v\()_\w\()x\h
      ret
  .endm
- 
+
 @@ -1284,7 +1284,7 @@
      mov             w6, #\h
      sub             x3, x3, #\w
@@ -1698,7 +1563,7 @@ index 95657db55..ab0ad2fae 100644
  .vl_gt_16_FILTER_LUMA_VPP_\v\()_\w\()x\h:
      ptrue           p0.h, vl8
 @@ -456,7 +456,7 @@
- 
+
  // void interp_vert_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
  .macro LUMA_VPP_SVE2 w, h
 -function x265_interp_8tap_vert_pp_\w\()x\h\()_sve2
@@ -1707,7 +1572,7 @@ index 95657db55..ab0ad2fae 100644
      b.eq            0f
      cmp             x4, #1
 @@ -501,7 +501,7 @@ LUMA_VPP_SVE2 64, 48
- 
+
  // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
  .macro LUMA_VPS_4xN_SVE2 h
 -function x265_interp_8tap_vert_ps_4x\h\()_sve2
@@ -1718,14 +1583,14 @@ index 95657db55..ab0ad2fae 100644
 @@ -522,7 +522,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_sve2
      ld1rd           {z22.d}, p0/z, [x12, #48]
      ld1rd           {z23.d}, p0/z, [x12, #56]
- 
+
 -.loop_vps_sve2_4x\h:
 +.Loop_vps_sve2_4x\h:
      mov             x6, x0
- 
+
      ld1b            {z0.s}, p0/z, [x6]
 @@ -557,7 +557,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_sve2
- 
+
      add             x0, x0, x1
      sub             x4, x4, #1
 -    cbnz            x4, .loop_vps_sve2_4x\h
@@ -1734,7 +1599,7 @@ index 95657db55..ab0ad2fae 100644
  endfunc
  .endm
 @@ -568,7 +568,7 @@ LUMA_VPS_4xN_SVE2 16
- 
+
  // void interp_vert_sp_c(const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
  .macro LUMA_VSP_4xN_SVE2 h
 -function x265_interp_8tap_vert_sp_4x\h\()_sve2
@@ -1745,14 +1610,14 @@ index 95657db55..ab0ad2fae 100644
 @@ -593,7 +593,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_sve2
      ld1rd           {z22.d}, p0/z, [x12, #48]
      ld1rd           {z23.d}, p0/z, [x12, #56]
- 
+
 -.loop_vsp_sve2_4x\h:
 +.Loop_vsp_sve2_4x\h:
      mov             x6, x0
- 
+
      ld1             {v0.8b}, [x6], x1
 @@ -630,7 +630,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_sve2
- 
+
      add             x0, x0, x1
      sub             x4, x4, #1
 -    cbnz            x4, .loop_vsp_sve2_4x\h
@@ -1788,7 +1653,7 @@ index 95657db55..ab0ad2fae 100644
  .vl_gt_16_FILTER_VPS_\v\()_\w\()x\h:
      ptrue           p0.h, vl8
 @@ -736,7 +736,7 @@ LUMA_VSP_4xN_SVE2 16
- 
+
  // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
  .macro LUMA_VPS_SVE2 w, h
 -function x265_interp_8tap_vert_ps_\w\()x\h\()_sve2
@@ -1822,7 +1687,7 @@ index 95657db55..ab0ad2fae 100644
 +    cbnz            x5, .Loop_luma_vss_sve2_\v\()_\w\()x\h
      ret
  .endm
- 
+
  // void interp_vert_ss_c(const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
  .macro LUMA_VSS_SVE2 w, h
 -function x265_interp_8tap_vert_ss_\w\()x\h\()_sve2
@@ -1856,7 +1721,7 @@ index 95657db55..ab0ad2fae 100644
 +    cbnz            x5, .Loop_chroma_vpp_sve2_\v\()_\w\()x\h
      ret
  .endm
- 
+
  // void interp_vert_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
  .macro CHROMA_VPP_SVE2 w, h
 -function x265_interp_4tap_vert_pp_\w\()x\h\()_sve2
@@ -1883,7 +1748,7 @@ index 95657db55..ab0ad2fae 100644
      cmp             x9, #\w
 -    blt             .loop_vps_w8_sve2_\v\()_\w\()x\h
 +    blt             .Loop_vps_w8_sve2_\v\()_\w\()x\h
- 
+
      add             x0, x0, x1
      add             x2, x2, x3
      sub             x5, x5, #1
@@ -1891,7 +1756,7 @@ index 95657db55..ab0ad2fae 100644
 +    cbnz            x5, .Loop_vps_sve2_\v\()_\w\()x\h
      ret
  .endm
- 
+
  // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
  .macro CHROMA_VPS_SVE2 w, h
 -function x265_interp_4tap_vert_ps_\w\()x\h\()_sve2
@@ -1931,7 +1796,7 @@ index 95657db55..ab0ad2fae 100644
 +    cbnz            x5, .Loop_vss_sve2_\v\()_\w\()x\h
      ret
  .endm
- 
+
  // void interp_vert_ss_c(const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
  .macro CHROMA_VSS_SVE2 w, h
 -function x265_interp_4tap_vert_ss_\w\()x\h\()_sve2
@@ -1954,7 +1819,7 @@ index 80624862d..0d1a374eb 100644
      sub             x0, x0, x1, lsl #1         // src -= 3 * srcStride
 @@ -85,7 +85,7 @@ function x265_interp_8tap_vert_pp_4x\h\()_neon
      ushll           v3.8h, v3.8b, #0
- 
+
      mov             x9, #\h
 -.loop_4x\h:
 +.Loop_4x\h:
@@ -1963,7 +1828,7 @@ index 80624862d..0d1a374eb 100644
      ushll           v4.8h, v4.8b, #0
 @@ -124,7 +124,7 @@ function x265_interp_8tap_vert_pp_4x\h\()_neon
      st1             {v16.s}[1], [x2], x3
- 
+
      sub             x9, x9, #2
 -    cbnz            x9, .loop_4x\h
 +    cbnz            x9, .Loop_4x\h
@@ -1971,7 +1836,7 @@ index 80624862d..0d1a374eb 100644
  endfunc
  .endm
 @@ -135,7 +135,7 @@ LUMA_VPP_4xN 16
- 
+
  // void interp_vert_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
  .macro LUMA_VPP w, h
 -function x265_interp_8tap_vert_pp_\w\()x\h\()_neon
@@ -1991,14 +1856,14 @@ index 80624862d..0d1a374eb 100644
 @@ -202,7 +202,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_neon
      ld1r            {v22.2d}, [x12], #8
      ld1r            {v23.2d}, [x12], #8
- 
+
 -.loop_vps_4x\h:
 +.Loop_vps_4x\h:
      mov             x6, x0
- 
+
      ld1             {v0.s}[0], [x6], x1
 @@ -252,7 +252,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_neon
- 
+
      add             x0, x0, x1
      sub             x4, x4, #1
 -    cbnz            x4, .loop_vps_4x\h
@@ -2007,7 +1872,7 @@ index 80624862d..0d1a374eb 100644
  endfunc
  .endm
 @@ -263,7 +263,7 @@ LUMA_VPS_4xN 16
- 
+
  // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
  .macro LUMA_VPS w, h
 -function x265_interp_8tap_vert_ps_\w\()x\h\()_neon
@@ -2031,10 +1896,10 @@ index 80624862d..0d1a374eb 100644
 -.loop_vsp_4x\h:
 +.Loop_vsp_4x\h:
      mov             x6, x0
- 
+
      ld1             {v0.8b}, [x6], x1
 @@ -368,7 +368,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_neon
- 
+
      add             x0, x0, x1
      sub             x4, x4, #1
 -    cbnz            x4, .loop_vsp_4x\h
@@ -2043,7 +1908,7 @@ index 80624862d..0d1a374eb 100644
  endfunc
  .endm
 @@ -379,7 +379,7 @@ LUMA_VSP_4xN 16
- 
+
  // void interp_vert_sp_c(const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
  .macro LUMA_VSP w, h
 -function x265_interp_8tap_vert_sp_\w\()x\h\()_neon
@@ -2139,12 +2004,12 @@ index cb6ad4cd9..37679c0b6 100644
 @@ -1,3 +1,4 @@
 +#include "common.h"
  #include "loopfilter-prim.h"
- 
+
  #define PIXEL_MIN 0
 @@ -11,12 +12,6 @@ namespace
  {
- 
- 
+
+
 -/* get the sign of input variable (TODO: this is a dup, make common) */
 -static inline int8_t signOf(int x)
 -{
@@ -2155,14 +2020,14 @@ index cb6ad4cd9..37679c0b6 100644
  {
      int16x8_t in = vsubl_u8(in0, in1);
 @@ -33,7 +28,7 @@ static void calSign_neon(int8_t *dst, const pixel *src1, const pixel *src2, cons
- 
+
      for (; x < endX; x++)
      {
 -        dst[x] = signOf(src1[x] - src2[x]);
 +        dst[x] = x265_signOf(src1[x] - src2[x]);
      }
  }
- 
+
 @@ -108,7 +103,7 @@ static void processSaoCUE1_neon(pixel *rec, int8_t *upBuff1, int8_t *offsetEo, i
      }
      for (; x < width; x++)
@@ -2229,7 +2094,7 @@ index 704bdaed0..e4540ce9b 100644
 +    cbnz            w12, .Loop_gt_32_pixel_avg_pp_48x64
      ret
  endfunc
- 
+
 @@ -339,7 +339,7 @@ function PFX(addAvg_6x\h\()_sve2)
      mov             w12, #\h / 2
      ptrue           p0.b, vl16
@@ -2515,7 +2380,7 @@ index 704bdaed0..e4540ce9b 100644
 +    cbnz            w12, .Loop_gt_112_sve2_addavg_48x64
      ret
  endfunc
- 
+
 @@ -817,7 +817,7 @@ function PFX(addAvg_64x\h\()_sve2)
      addAvg_start
      sub             x3, x3, #64
@@ -2709,7 +2574,7 @@ index d122b8bb3..8c2878b3e 100644
 +    cbnz            w12, .Loop_addavg_48x64
      ret
  endfunc
- 
+
 @@ -523,7 +523,7 @@ function PFX(addAvg_64x\h\()_neon)
      mov             w12, #\h
      sub             x3, x3, #64
@@ -2859,7 +2724,7 @@ index 7164cd99f..f073251d3 100644
 +            uint32x4_t sum23 = vpaddlq_u16(vpaddq_u16(vsum16_2, vsum16_3));
 +            result = vaddq_u32(result, vpaddq_u32(sum01, sum23));
          }
- 
+
  #else
 diff --git a/source/common/aarch64/pixel-util-sve.S b/source/common/aarch64/pixel-util-sve.S
 index 715fcc1cb..c1d6b4129 100644
@@ -2868,7 +2733,7 @@ index 715fcc1cb..c1d6b4129 100644
 @@ -333,7 +333,7 @@ function PFX(quant_sve)
      eor             w10, w10, w10
      eor             z17.d, z17.d, z17.d
- 
+
 -.loop_quant_sve:
 +.Loop_quant_sve:
      ld1             {v18.4h}, [x0], #8
@@ -2876,11 +2741,11 @@ index 715fcc1cb..c1d6b4129 100644
      sxtl            v6.4s, v18.4h
 @@ -364,7 +364,7 @@ function PFX(quant_sve)
      st1             {v5.4h}, [x3], #8
- 
+
      subs            w6, w6, #1
 -    b.ne             .loop_quant_sve
 +    b.ne             .Loop_quant_sve
- 
+
      addv            s4, v4.4s
      mov             w9, v4.s[0]
 diff --git a/source/common/aarch64/pixel-util-sve2.S b/source/common/aarch64/pixel-util-sve2.S
@@ -3198,7 +3063,7 @@ index 9b3c11504..1df49ba6e 100644
 +    cbnz            w12, .Loop_residual_32
      ret
  endfunc
- 
+
 @@ -221,7 +221,7 @@ endfunc
  function PFX(pixel_sub_ps_32x32_neon)
      lsl             x1, x1, #1
@@ -3216,7 +3081,7 @@ index 9b3c11504..1df49ba6e 100644
 +    cbnz            w12, .Loop_sub_ps_32
      ret
  endfunc
- 
+
 @@ -247,7 +247,7 @@ function PFX(pixel_sub_ps_64x64_neon)
      lsl             x1, x1, #1
      sub             x1, x1, #64
@@ -3234,7 +3099,7 @@ index 9b3c11504..1df49ba6e 100644
 +    cbnz            w12, .Loop_sub_ps_64
      ret
  endfunc
- 
+
 @@ -318,7 +318,7 @@ endfunc
  function PFX(pixel_sub_ps_32x64_neon)
      lsl             x1, x1, #1
@@ -3252,7 +3117,7 @@ index 9b3c11504..1df49ba6e 100644
 +    cbnz            w12, .Loop_sub_ps_32x64
      ret
  endfunc
- 
+
 @@ -383,7 +383,7 @@ endfunc
  function PFX(pixel_add_ps_16x\h\()_neon)
      lsl             x5, x5, #1
@@ -3306,7 +3171,7 @@ index 9b3c11504..1df49ba6e 100644
 +    cbnz            w12, .Loop_add_ps_64x64
      ret
  endfunc
- 
+
 @@ -548,7 +548,7 @@ endfunc
  // void scale2D_64to32(pixel* dst, const pixel* src, intptr_t stride)
  function PFX(scale2D_64to32_neon)
@@ -3324,7 +3189,7 @@ index 9b3c11504..1df49ba6e 100644
 +    cbnz            w12, .Loop_scale2D
      ret
  endfunc
- 
+
 @@ -569,33 +569,33 @@ endfunc
  function PFX(pixel_planecopy_cp_neon)
      dup             v2.16b, w6
@@ -3343,13 +3208,13 @@ index 9b3c11504..1df49ba6e 100644
      cmp             x7, x4
 -    blt             .loop_w
 +    blt             .Loop_w
- 
+
      add             x0, x0, x1
      add             x2, x2, x3
      sub             x5, x5, #1
 -    cbnz            x5, .loop_h
 +    cbnz            x5, .Loop_h
- 
+
  // handle last row
      mov             x5, x4
      lsr             x5, x5, #3
@@ -3362,7 +3227,7 @@ index 9b3c11504..1df49ba6e 100644
      sub             x5, x5, #1
 -    cbnz            x5, .loopW8
 +    cbnz            x5, .LoopW8
- 
+
      mov             x5, #8
      sub             x5, x5, x4
 @@ -1508,7 +1508,7 @@ function PFX(pixel_sa8d_32x64_neon)
@@ -3393,7 +3258,7 @@ index 9b3c11504..1df49ba6e 100644
      sa8d_16x16      w4
      sub             x0, x0, x1, lsl #4
 @@ -1554,7 +1554,7 @@ function PFX(pixel_sa8d_64x64_neon)
- 
+
      sub             x0, x0, #56
      sub             x2, x2, #56
 -    cbnz            w11, .loop_sa8d_64
@@ -3404,25 +3269,25 @@ index 9b3c11504..1df49ba6e 100644
 @@ -1807,7 +1807,7 @@ function PFX(quant_neon)
      eor             w10, w10, w10
      eor             v17.16b, v17.16b, v17.16b
- 
+
 -.loop_quant:
 +.Loop_quant:
- 
+
      ld1             {v18.4h}, [x0], #8
      ld1             {v7.4s}, [x1], #16
 @@ -1839,7 +1839,7 @@ function PFX(quant_neon)
      st1             {v5.4h}, [x3], #8
- 
+
      subs            w6, w6, #1
 -    b.ne             .loop_quant
 +    b.ne             .Loop_quant
- 
+
      addv            s4, v4.4s
      mov             w9, v4.s[0]
 @@ -1858,7 +1858,7 @@ function PFX(nquant_neon)
      mov             x4, #0
      movi            v22.4s, #0
- 
+
 -.loop_nquant:
 +.Loop_nquant:
      ld1             {v16.4h}, [x0], #8
@@ -3431,10 +3296,10 @@ index 9b3c11504..1df49ba6e 100644
 @@ -1883,7 +1883,7 @@ function PFX(nquant_neon)
      abs             v17.4h, v16.4h
      st1             {v17.4h}, [x2], #8
- 
+
 -    cbnz            w5, .loop_nquant
 +    cbnz            w5, .Loop_nquant
- 
+
      uaddlv          d4, v4.4s
      fmov            x12, d4
 @@ -1937,7 +1937,7 @@ endfunc
@@ -3546,7 +3411,7 @@ index 9b3c11504..1df49ba6e 100644
  endfunc
 @@ -2120,9 +2120,9 @@ function PFX(weight_pp_neon)
      cbnz            w11, .widenTo32Bit
- 
+
      // 16-bit arithmetic is enough.
 -.loopHpp:
 +.LoopHpp:
@@ -3568,7 +3433,7 @@ index 9b3c11504..1df49ba6e 100644
 -    cbnz            x4, .loopHpp
 +    cbnz            x4, .LoopHpp
      ret
- 
+
      // 32-bit arithmetic is needed.
  .widenTo32Bit:
 -.loopHpp32:
@@ -3591,7 +3456,7 @@ index 9b3c11504..1df49ba6e 100644
 -    cbnz            x4, .loopHpp32
 +    cbnz            x4, .LoopHpp32
      ret
- 
+
      // The shift right cannot be moved out of the loop.
 @@ -2169,9 +2169,9 @@ function PFX(weight_pp_neon)
      neg             w7, w7                // -shift
@@ -3618,11 +3483,11 @@ index 9b3c11504..1df49ba6e 100644
 +    cbnz            x4, .LoopHppUS
      ret
  endfunc
- 
+
 @@ -2220,7 +2220,7 @@ function PFX(scanPosLast_neon)
      add             x11, x10, x7    // 3*x7
      add             x9, x4, #1      // CG count
- 
+
 -.loop_spl:
 +.Loop_spl:
      // position of current CG
@@ -3644,14 +3509,14 @@ index 9b3c11504..1df49ba6e 100644
 +    b               .Loop_spl_1
  .pext_end:
      strh            w14, [x2], #2
- 
+
 @@ -2285,7 +2285,7 @@ function PFX(scanPosLast_neon)
      sub             x5, x5, x6
      strb            w6, [x4], #1
- 
+
 -    cbnz            x5, .loop_spl
 +    cbnz            x5, .Loop_spl
- 
+
      // count trailing zeros
      rbit            w13, w12
 @@ -2311,7 +2311,7 @@ endfunc
@@ -3679,11 +3544,11 @@ index 9b3c11504..1df49ba6e 100644
 -    cbnz            x2, .loop_ccnn
 +    cbnz            x2, .Loop_ccnn
  .idx_zero:
- 
+
      add             x13, x3, x4, lsl #1
      add             x4, x4, x15
      str             h2, [x13]              // absCoeff[numNonZero] = tmpCoeff[blkPos]
- 
+
 -    ldr             x9, [sp, #8]           // subPosBase
 +    ldr             x9, [sp, #STACK_ARG_OFFSET(1)]           // subPosBase
      uxth            w9, w9
@@ -3695,7 +3560,7 @@ index 9c86d84b6..599a3719a 100644
 +++ b/source/common/aarch64/sad-a-sve2.S
 @@ -217,12 +217,12 @@ function PFX(pixel_sad_\w\()x\h\()_sve2)
      SAD_START_\w
- 
+
      mov             w9, #\h/8
 -.loop_sve2_\w\()x\h:
 +.Loop_sve2_\w\()x\h:
@@ -3705,12 +3570,12 @@ index 9c86d84b6..599a3719a 100644
  .endr
 -    cbnz            w9, .loop_sve2_\w\()x\h
 +    cbnz            w9, .Loop_sve2_\w\()x\h
- 
+
      SAD_END_\w
- 
+
 @@ -231,12 +231,12 @@ function PFX(pixel_sad_\w\()x\h\()_sve2)
      SAD_START_\w
- 
+
      mov             w9, #\h/8
 -.loop_sve2_loop_\w\()x\h:
 +.Loop_sve2_loop_\w\()x\h:
@@ -3720,7 +3585,7 @@ index 9c86d84b6..599a3719a 100644
  .endr
 -    cbnz            w9, .loop_sve2_loop_\w\()x\h
 +    cbnz            w9, .Loop_sve2_loop_\w\()x\h
- 
+
      SAD_END_\w
  .else
 @@ -402,7 +402,7 @@ function PFX(sad_x\x\()_\w\()x\h\()_sve2)
@@ -3765,7 +3630,7 @@ index 20d7cac7c..7460825f1 100644
 +++ b/source/common/aarch64/sad-a.S
 @@ -55,12 +55,12 @@ function PFX(pixel_sad_\w\()x\h\()_neon)
      SAD_START_\w
- 
+
      mov             w9, #\h/8
 -.loop_\w\()x\h:
 +.Loop_\w\()x\h:
@@ -3775,7 +3640,7 @@ index 20d7cac7c..7460825f1 100644
  .endr
 -    cbnz            w9, .loop_\w\()x\h
 +    cbnz            w9, .Loop_\w\()x\h
- 
+
      SAD_END_\w
  endfunc
 @@ -129,7 +129,7 @@ function PFX(sad_x\x\()_\w\()x\h\()_neon)
@@ -4582,7 +4447,7 @@ index de2603850..8077bd93c 100644
 @@ -182,7 +182,7 @@ function PFX(pixel_sse_pp_64x64_sve2)
      movi            v0.16b, #0
      movi            v1.16b, #0
- 
+
 -.loop_sse_pp_64_sve2:
 +.Loop_sse_pp_64_sve2:
      sub             w12, w12, #1
@@ -4676,7 +4541,7 @@ index 7c778b4fe..f4b79304a 100644
 @@ -212,7 +212,7 @@ function PFX(pixel_sse_pp_64x64_neon)
      movi            v0.16b, #0
      movi            v1.16b, #0
- 
+
 -.loop_sse_pp_64:
 +.Loop_sse_pp_64:
      sub             w12, w12, #1
@@ -4788,19 +4653,19 @@ index 1c868f464..8170160aa 100644
 @@ -795,7 +795,7 @@ function x265_count_nonzero_32_neon
      vmov            q2, q12
      vmov            q3, q14
- 
--.loop:    
+
+-.loop:
 +.Loop:
      vldm            r0!, {q8-q15}
      subs            r1, #1
- 
+
 @@ -817,7 +817,7 @@ function x265_count_nonzero_32_neon
      vadd.s8         q1, q10
      vadd.s8         q2, q12
      vadd.s8         q3, q14
 -    bgt            .loop
 +    bgt            .Loop
- 
+
      // sum
      vadd.s8         q0, q1
 diff --git a/source/common/arm/dct-a.S b/source/common/arm/dct-a.S
@@ -4809,7 +4674,7 @@ index 42b193bf8..5be8847e9 100644
 +++ b/source/common/arm/dct-a.S
 @@ -422,7 +422,7 @@ function x265_dct_16x16_neon
      mov lr, #4*16*2
- 
+
      // DCT-1D
 -.loop1:
 +.Loop1:
@@ -4822,25 +4687,25 @@ index 42b193bf8..5be8847e9 100644
      subs r12, #1
 -    bgt .loop1
 +    bgt .Loop1
- 
- 
+
+
      // DCT-2D
 @@ -637,7 +637,7 @@ function x265_dct_16x16_neon
      mov r3, #16*2*2
      mov r12, #16/4                      // Process 4 rows every loop
- 
+
 -.loop2:
 +.Loop2:
      vldm r2, {q8-q15}
- 
+
      // d16 = [30 20 10 00]
 @@ -887,7 +887,7 @@ function x265_dct_16x16_neon
- 
+
      sub r1, #(17*16-4)*2
      subs r12, #1
 -    bgt .loop2
 +    bgt .Loop2
- 
+
      add sp, #16*16*2
      vpop {q4-q7}
 diff --git a/source/common/arm/ipfilter8.S b/source/common/arm/ipfilter8.S
@@ -4864,7 +4729,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 +    bgt         .Loop_filterP2S_32x16
      bx          lr
  endfunc
- 
+
 @@ -402,7 +402,7 @@ function x265_filterPixelToShort_32x24_neon
      vmov.u16    q1, #8192
      vneg.s16    q1, q1
@@ -4882,7 +4747,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 +    bgt         .Loop_filterP2S_32x24
      bx          lr
  endfunc
- 
+
 @@ -432,7 +432,7 @@ function x265_filterPixelToShort_32x32_neon
      vmov.u16    q1, #8192
      vneg.s16    q1, q1
@@ -4900,7 +4765,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 +    bgt         .Loop_filterP2S_32x32
      bx          lr
  endfunc
- 
+
 @@ -462,7 +462,7 @@ function x265_filterPixelToShort_32x64_neon
      vmov.u16    q1, #8192
      vneg.s16    q1, q1
@@ -4918,7 +4783,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 +    bgt         .Loop_filterP2S_32x64
      bx          lr
  endfunc
- 
+
 @@ -493,7 +493,7 @@ function x265_filterPixelToShort_64x16_neon
      vmov.u16    q1, #8192
      vneg.s16    q1, q1
@@ -4936,7 +4801,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 +    bgt         .Loop_filterP2S_64x16
      bx          lr
  endfunc
- 
+
 @@ -540,7 +540,7 @@ function x265_filterPixelToShort_64x32_neon
      vmov.u16    q1, #8192
      vneg.s16    q1, q1
@@ -4954,7 +4819,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 +    bgt         .Loop_filterP2S_64x32
      bx          lr
  endfunc
- 
+
 @@ -587,7 +587,7 @@ function x265_filterPixelToShort_64x48_neon
      vmov.u16    q1, #8192
      vneg.s16    q1, q1
@@ -4972,7 +4837,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 +    bgt         .Loop_filterP2S_64x48
      bx          lr
  endfunc
- 
+
 @@ -634,7 +634,7 @@ function x265_filterPixelToShort_64x64_neon
      vmov.u16    q1, #8192
      vneg.s16    q1, q1
@@ -4990,7 +4855,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 +    bgt         .Loop_filterP2S_64x64
      bx          lr
  endfunc
- 
+
 @@ -681,7 +681,7 @@ function x265_filterPixelToShort_48x64_neon
      vmov.u16    q1, #8192
      vneg.s16    q1, q1
@@ -5008,11 +4873,11 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 +    bgt         .Loop_filterP2S_48x64
      bx          lr
  endfunc
- 
+
 @@ -756,7 +756,7 @@ function x265_interp_8tap_vert_pp_4x\h\()_neon
      vmovl.u8    q2, d4
      vmovl.u8    q3, d6
- 
+
 -.loop_4x\h:
 +.Loop_4x\h:
      // TODO: read extra 1 row for speed optimize, may made crash on OS X platform!
@@ -5020,51 +4885,51 @@ index 8b7f5b3ca..b1ec6cc8b 100644
      vld1.u32    {d16[1]}, [r0], r1
 @@ -795,7 +795,7 @@ function x265_interp_8tap_vert_pp_4x\h\()_neon
      vst1.u32    {d18[1]}, [r2], r3
- 
+
      subs        r12, #2
 -    bne        .loop_4x4
 +    bne        .Loop_4x4
- 
+
      pop         {pc}
      .ltorg
 @@ -945,13 +945,13 @@ LUMA_VPP_4xN 16
- 
+
  .macro FILTER_VPP a b filterv
- 
+
 -.loop_\filterv\()_\a\()x\b:
 +.Loop_\filterv\()_\a\()x\b:
- 
+
      mov             r7, r2
      mov             r6, r0
      eor             r8, r8
- 
+
 -.loop_w8_\filterv\()_\a\()x\b:
 +.Loop_w8_\filterv\()_\a\()x\b:
- 
+
      add             r6, r0, r8
- 
+
 @@ -988,12 +988,12 @@ LUMA_VPP_4xN 16
- 
+
      add             r8, #8
      cmp             r8, #\a
 -    blt             .loop_w8_\filterv\()_\a\()x\b
 +    blt             .Loop_w8_\filterv\()_\a\()x\b
- 
+
      add             r0, r1
      add             r2, r3
      subs            r4, #1
--    bne             .loop_\filterv\()_\a\()x\b 
+-    bne             .loop_\filterv\()_\a\()x\b
 +    bne             .Loop_\filterv\()_\a\()x\b
- 
- .endm 
- 
+
+ .endm
+
 @@ -1063,7 +1063,7 @@ function x265_interp_8tap_vert_pp_12x16_neon
      sub             r0, r4
- 
+
      mov             r4, #16
 -.loop_vpp_12x16:
 +.Loop_vpp_12x16:
- 
+
      mov             r6, r0
      mov             r7, r2
 @@ -1173,7 +1173,7 @@ function x265_interp_8tap_vert_pp_12x16_neon
@@ -5073,7 +4938,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
      subs            r4, #1
 -    bne             .loop_vpp_12x16
 +    bne             .Loop_vpp_12x16
- 
+
      pop             {r4, r5, r6, r7}
      bx              lr
 @@ -1194,7 +1194,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_neon
@@ -5086,7 +4951,7 @@ index 8b7f5b3ca..b1ec6cc8b 100644
      add             r12, r5
      mov             r6, r0
 @@ -1266,7 +1266,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_neon
- 
+
      add             r0, r1
      subs            r4, #1
 -    bne             .loop_vsp_4x\h
@@ -5096,42 +4961,42 @@ index 8b7f5b3ca..b1ec6cc8b 100644
      .ltorg
 @@ -1369,13 +1369,13 @@ LUMA_VSP_4xN 16
  .macro FILTER_VSP a b filterv
- 
+
      vpush           { q4 - q7}
 -.loop_\filterv\()_\a\()x\b:
 +.Loop_\filterv\()_\a\()x\b:
- 
+
      mov             r7, r2
      mov             r6, r0
      eor             r8, r8
- 
+
 -.loop_w8_\filterv\()_\a\()x\b:
 +.Loop_w8_\filterv\()_\a\()x\b:
- 
+
      add             r6, r0, r8
- 
+
 @@ -1417,12 +1417,12 @@ LUMA_VSP_4xN 16
      mov             r12, #\a
      lsl             r12, #1
      cmp             r8, r12
 -    blt             .loop_w8_\filterv\()_\a\()x\b
 +    blt             .Loop_w8_\filterv\()_\a\()x\b
- 
+
      add             r0, r1
      add             r2, r3
      subs            r4, #1
 -    bne             .loop_\filterv\()_\a\()x\b
 +    bne             .Loop_\filterv\()_\a\()x\b
- 
+
      vpop            { q4 - q7}
- 
+
 @@ -1498,7 +1498,7 @@ function x265_interp_8tap_vert_sp_12x16_neon
- 
+
      mov             r4, #16
      vpush           { q4 - q7}
 -.loop1_12x16:
 +.Loop1_12x16:
- 
+
      mov             r6, r0
      mov             r7, r2
 @@ -1612,7 +1612,7 @@ function x265_interp_8tap_vert_sp_12x16_neon
@@ -5146,59 +5011,59 @@ index 8b7f5b3ca..b1ec6cc8b 100644
 @@ -1632,7 +1632,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_neon
      vdup.32         q8, r4
      mov             r4, #\h
- 
+
 -.loop_vps_4x\h:
 +.Loop_vps_4x\h:
      movrel          r12, g_lumaFilter
      add             r12, r5
      mov             r6, r0
 @@ -1702,7 +1702,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_neon
- 
+
      add             r0, r1
      subs            r4, #1
 -    bne             .loop_vps_4x\h
 +    bne             .Loop_vps_4x\h
- 
+
      pop             {r4, r5, r6}
      bx              lr
 @@ -1717,13 +1717,13 @@ LUMA_VPS_4xN 16
- 
+
  .macro FILTER_VPS a b filterv
- 
+
 -.loop_ps_\filterv\()_\a\()x\b:
 +.Loop_ps_\filterv\()_\a\()x\b:
- 
+
      mov             r7, r2
      mov             r6, r0
      eor             r8, r8
- 
+
 -.loop_ps_w8_\filterv\()_\a\()x\b:
 +.Loop_ps_w8_\filterv\()_\a\()x\b:
- 
+
      add             r6, r0, r8
- 
+
 @@ -1759,12 +1759,12 @@ LUMA_VPS_4xN 16
- 
+
      add             r8, #8
      cmp             r8, #\a
 -    blt             .loop_ps_w8_\filterv\()_\a\()x\b
 +    blt             .Loop_ps_w8_\filterv\()_\a\()x\b
- 
+
      add             r0, r1
      add             r2, r3
      subs            r4, #1
--    bne             .loop_ps_\filterv\()_\a\()x\b 
+-    bne             .loop_ps_\filterv\()_\a\()x\b
 +    bne             .Loop_ps_\filterv\()_\a\()x\b
- 
- .endm 
- 
+
+ .endm
+
 @@ -1836,7 +1836,7 @@ function x265_interp_8tap_vert_ps_12x16_neon
      sub             r0, r4
- 
+
      mov             r4, #16
 -.loop_vps_12x16:
 +.Loop_vps_12x16:
- 
+
      mov             r6, r0
      mov             r7, r2
 @@ -1942,7 +1942,7 @@ function x265_interp_8tap_vert_ps_12x16_neon
@@ -5207,102 +5072,102 @@ index 8b7f5b3ca..b1ec6cc8b 100644
      subs            r4, #1
 -    bne             .loop_vps_12x16
 +    bne             .Loop_vps_12x16
- 
+
      pop             {r4, r5, r6, r7}
      bx              lr
 @@ -2081,13 +2081,13 @@ endfunc
- 
+
      vpush           {q4-q7}
- 
+
 -.loop_\filterv\()_\a\()x\b:
 +.Loop_\filterv\()_\a\()x\b:
- 
+
      mov             r7, r2
      mov             r6, r0
      eor             r8, r8
- 
+
 -.loop_w8_\filterv\()_\a\()x\b:
 +.Loop_w8_\filterv\()_\a\()x\b:
- 
+
      add             r6, r0, r8
- 
+
 @@ -2121,12 +2121,12 @@ endfunc
- 
+
      add             r8, #8
      cmp             r8, #\a
 -    blt             .loop_w8_\filterv\()_\a\()x\b
 +    blt             .Loop_w8_\filterv\()_\a\()x\b
- 
+
      add             r0, r1
      add             r2, r3
      subs            r4, #1
--    bne             .loop_\filterv\()_\a\()x\b 
+-    bne             .loop_\filterv\()_\a\()x\b
 +    bne             .Loop_\filterv\()_\a\()x\b
      vpop            {q4-q7}
- .endm 
- 
+ .endm
+
 @@ -2217,13 +2217,13 @@ CHROMA_VPP 48 64
- 
+
      vpush           {q4-q7}
- 
+
 -.loop_vps_\filterv\()_\a\()x\b:
 +.Loop_vps_\filterv\()_\a\()x\b:
- 
+
      mov             r7, r2
      mov             r6, r0
      eor             r8, r8
- 
+
 -.loop_vps_w8_\filterv\()_\a\()x\b:
 +.Loop_vps_w8_\filterv\()_\a\()x\b:
- 
+
      add             r6, r0, r8
- 
+
 @@ -2256,12 +2256,12 @@ CHROMA_VPP 48 64
- 
+
      add             r8, #8
      cmp             r8, #\a
 -    blt             .loop_vps_w8_\filterv\()_\a\()x\b
 +    blt             .Loop_vps_w8_\filterv\()_\a\()x\b
- 
+
      add             r0, r1
      add             r2, r3
      subs            r4, #1
--    bne             .loop_vps_\filterv\()_\a\()x\b 
+-    bne             .loop_vps_\filterv\()_\a\()x\b
 +    bne             .Loop_vps_\filterv\()_\a\()x\b
      vpop            {q4-q7}
- .endm 
- 
+ .endm
+
 @@ -2353,13 +2353,13 @@ CHROMA_VPS 48 64
- 
+
      vpush           {q4-q7}
- 
+
 -.loop_vsp_\filterv\()_\a\()x\b:
 +.Loop_vsp_\filterv\()_\a\()x\b:
- 
+
      mov             r7, r2
      mov             r6, r0
      eor             r8, r8
- 
+
 -.loop_vsp_w8_\filterv\()_\a\()x\b:
 +.Loop_vsp_w8_\filterv\()_\a\()x\b:
- 
+
      add             r6, r0, r8
- 
+
 @@ -2392,12 +2392,12 @@ CHROMA_VPS 48 64
      mov             r12, #\a
      lsl             r12, #1
      cmp             r8, r12
 -    blt             .loop_vsp_w8_\filterv\()_\a\()x\b
 +    blt             .Loop_vsp_w8_\filterv\()_\a\()x\b
- 
+
      add             r0, r1
      add             r2, r3
      subs            r4, #1
--    bne             .loop_vsp_\filterv\()_\a\()x\b 
+-    bne             .loop_vsp_\filterv\()_\a\()x\b
 +    bne             .Loop_vsp_\filterv\()_\a\()x\b
      vpop            {q4-q7}
- .endm 
- 
+ .endm
+
 diff --git a/source/common/arm/mc-a.S b/source/common/arm/mc-a.S
 index b10e9e816..839d192cd 100644
 --- a/source/common/arm/mc-a.S
@@ -5324,7 +5189,7 @@ index b10e9e816..839d192cd 100644
 +    bgt             .Loop_cpy2Dto1D_shr_16
      bx              lr
  endfunc
- 
+
 @@ -577,7 +577,7 @@ function x265_cpy2Dto1D_shr_32x32_neon
      vsri.s16        q1, #1
      vneg.s16        q0, q0
@@ -5342,7 +5207,7 @@ index b10e9e816..839d192cd 100644
 +    bgt             .Loop_cpy2Dto1D_shr_32
      bx              lr
  endfunc
- 
+
 diff --git a/source/common/arm/pixel-util.S b/source/common/arm/pixel-util.S
 index c26b17acc..67719c8e5 100644
 --- a/source/common/arm/pixel-util.S
@@ -5350,7 +5215,7 @@ index c26b17acc..67719c8e5 100644
 @@ -848,36 +848,36 @@ function x265_pixel_planecopy_cp_neon
      vdup.8          q2, r12
      sub             r5, #1
- 
+
 -.loop_h:
 +.Loop_h:
      mov             r6, r0
@@ -5361,23 +5226,23 @@ index c26b17acc..67719c8e5 100644
      vld1.u8         {q0}, [r6]!
      vshl.u8         q0, q0, q2
      vst1.u8         {q0}, [r12]!
- 
+
      add             r7, #16
      cmp             r7, r4
 -    blt             .loop_w
 +    blt             .Loop_w
- 
+
      add             r0, r1
      add             r2, r3
- 
+
      subs             r5, #1
 -    bgt             .loop_h
 +    bgt             .Loop_h
- 
+
  // handle last row
      mov             r5, r4
      lsr             r5, #3
- 
+
 -.loopW8:
 +.LoopW8:
      vld1.u8         d0, [r0]!
@@ -5387,79 +5252,79 @@ index c26b17acc..67719c8e5 100644
      subs            r5, #1
 -    bgt             .loopW8
 +    bgt             .LoopW8
- 
+
      mov             r5,#8
      sub             r5, r4
 @@ -1970,7 +1970,7 @@ function x265_quant_neon
      eor             r5, r5
      veor.s32        q12, q12
- 
+
 -.loop_quant:
 +.Loop_quant:
- 
+
      vld1.s16        d16, [r0]!
      vmovl.s16       q9, d16                // q9= coef[blockpos]
 @@ -1999,7 +1999,7 @@ function x265_quant_neon
      vst1.s16        d16, [r3]!
- 
+
      subs            r4, #1
 -    bne             .loop_quant
 +    bne             .Loop_quant
- 
+
      vadd.u32        d8, d9
      vpadd.u32       d8, d8
 @@ -2023,7 +2023,7 @@ function x265_nquant_neon
      eor             r4, r4
      veor.s32        q12, q12
- 
+
 -.loop_nquant:
 +.Loop_nquant:
- 
+
      vld1.s16        d16, [r0]!
      vmovl.s16       q9, d16                // q9= coef[blockpos]
 @@ -2049,7 +2049,7 @@ function x265_nquant_neon
      vst1.s16        d17, [r2]!
- 
+
      subs            r3, #1
 -    bne             .loop_nquant
 +    bne             .Loop_nquant
- 
+
      vadd.u32        d8, d9
      vpadd.u32       d8, d8
 @@ -2148,7 +2148,7 @@ function x265_pixel_sa8d_32x64_neon
      mov             r10, #4
      eor             r9, r9
- 
+
 -.loop_32:
 +.Loop_32:
- 
+
      sa8d_16x16 r4
- 
+
 @@ -2166,7 +2166,7 @@ function x265_pixel_sa8d_32x64_neon
      sub             r2,  r2,  #24
- 
+
      subs            r10, #1
 -    bgt            .loop_32
 +    bgt            .Loop_32
- 
+
      mov             r0, r9
      vpop            {d8-d11}
 @@ -2183,7 +2183,7 @@ function x265_pixel_sa8d_64x64_neon
      mov             r10, #4
      eor             r9, r9
- 
+
 -.loop_1:
 +.Loop_1:
- 
+
      sa8d_16x16 r4
- 
+
 @@ -2217,7 +2217,7 @@ function x265_pixel_sa8d_64x64_neon
      sub             r2,  r2,  #56
- 
+
      subs            r10, #1
 -    bgt            .loop_1
 +    bgt            .Loop_1
- 
+
      mov             r0, r9
      vpop            {d8-d11}
 diff --git a/source/common/arm/sad-a.S b/source/common/arm/sad-a.S
@@ -5469,10 +5334,10 @@ index 6faf35957..b5cbded89 100644
 @@ -103,7 +103,7 @@ function x265_pixel_sad_16x\h\()_neon
      vabal.u8        q9, d5, d7
      mov             r12, #(\h-2)/2
- 
+
 -.loop_16x\h:
 +.Loop_16x\h:
- 
+
      subs            r12, #1
      vld1.8          {q0}, [r0], r1
 @@ -115,7 +115,7 @@ function x265_pixel_sad_16x\h\()_neon
@@ -5481,16 +5346,16 @@ index 6faf35957..b5cbded89 100644
      vabal.u8        q9, d5, d7
 -    bne             .loop_16x\h
 +    bne             .Loop_16x\h
- 
+
      vadd.u16        q8, q8, q9
  .if \h == 64
 @@ -147,7 +147,7 @@ function x265_pixel_sad_32x\h\()_neon
      veor.u8         q11, q11
      mov             r12, #\h/8
- 
+
 -.loop_32x\h:
 +.Loop_32x\h:
- 
+
      subs            r12, #1
  .rept 4
 @@ -166,7 +166,7 @@ function x265_pixel_sad_32x\h\()_neon
@@ -5499,16 +5364,16 @@ index 6faf35957..b5cbded89 100644
  .endr
 -    bne             .loop_32x\h
 +    bne             .Loop_32x\h
- 
+
      vadd.u16        q8, q8, q9
      vadd.u16        q10, q10, q11
 @@ -213,7 +213,7 @@ function x265_pixel_sad_64x\h\()_neon
      sub             r3, r12
      mov             r12, #\h/8
- 
+
 -.loop_64x\h:
 +.Loop_64x\h:
- 
+
      subs            r12, #1
  .rept 4
 @@ -246,7 +246,7 @@ function x265_pixel_sad_64x\h\()_neon
@@ -5517,16 +5382,16 @@ index 6faf35957..b5cbded89 100644
  .endr
 -    bne             .loop_64x\h
 +    bne             .Loop_64x\h
- 
+
      vadd.u16        q8, q8, q9
      vadd.u16        q10, q10, q11
 @@ -283,7 +283,7 @@ function x265_pixel_sad_24x32_neon
      sub             r3, #16
      mov             r12, #8
- 
+
 -.loop_24x32:
 +.Loop_24x32:
- 
+
      subs            r12, #1
  .rept 4
 @@ -296,7 +296,7 @@ function x265_pixel_sad_24x32_neon
@@ -5535,16 +5400,16 @@ index 6faf35957..b5cbded89 100644
  .endr
 -    bne             .loop_24x32
 +    bne             .Loop_24x32
- 
+
      vadd.u16        q8, q8, q9
      vadd.u16        d16, d16, d17
 @@ -322,7 +322,7 @@ function x265_pixel_sad_48x64_neon
      sub             r3, #32
      mov             r12, #16
- 
+
 -.loop_48x64:
 +.Loop_48x64:
- 
+
      subs            r12, #1
  .rept 4
 @@ -337,7 +337,7 @@ function x265_pixel_sad_48x64_neon
@@ -5553,13 +5418,13 @@ index 6faf35957..b5cbded89 100644
  .endr
 -    bne             .loop_48x64
 +    bne             .Loop_48x64
- 
+
      vadd.u16        q3, q3, q11
      vadd.u16        d6, d6, d7
 @@ -635,12 +635,12 @@ function x265_sad_x\x\()_16x\h\()_neon
      veor.u8         q15, q15
  .endif
- 
+
 -.loop_sad_x\x\()_16x\h:
 +.Loop_sad_x\x\()_16x\h:
  .rept 8
@@ -5568,7 +5433,7 @@ index 6faf35957..b5cbded89 100644
      subs            r6, #1
 -    bne             .loop_sad_x\x\()_16x\h
 +    bne             .Loop_sad_x\x\()_16x\h
- 
+
      vadd.u16        q8, q8, q9
      vadd.u16        q10, q10, q11
 @@ -929,12 +929,12 @@ function x265_sad_x\x\()_64x\h\()_neon
@@ -5583,13 +5448,13 @@ index 6faf35957..b5cbded89 100644
      subs            r6, #1
 -    bne             .loop_sad_x\x\()_64x\h
 +    bne             .Loop_sad_x\x\()_64x\h
- 
+
  .if \h <= 16
      vadd.u16        q8, q8, q9
 @@ -1071,12 +1071,12 @@ function x265_sad_x\x\()_48x64_neon
      veor.u8         q15, q15
  .endif
- 
+
 -.loop_sad_x\x\()_48x64:
 +.Loop_sad_x\x\()_48x64:
  .rept 8
@@ -5598,13 +5463,13 @@ index 6faf35957..b5cbded89 100644
      subs            r6, #1
 -    bne             .loop_sad_x\x\()_48x64
 +    bne             .Loop_sad_x\x\()_48x64
- 
+
      vpaddl.u16      q8, q8
      vpaddl.u16      q9, q9
 @@ -1179,12 +1179,12 @@ function x265_sad_x\x\()_24x32_neon
      veor.u8         q15, q15
  .endif
- 
+
 -.loop_sad_x\x\()_24x32:
 +.Loop_sad_x\x\()_24x32:
  .rept 8
@@ -5613,7 +5478,7 @@ index 6faf35957..b5cbded89 100644
      subs            r6, #1
 -    bne             .loop_sad_x\x\()_24x32
 +    bne             .Loop_sad_x\x\()_24x32
- 
+
      vadd.u16        q8, q8, q9
      vadd.u16        q10, q10, q11
 diff --git a/source/common/arm/ssd-a.S b/source/common/arm/ssd-a.S
@@ -5623,7 +5488,7 @@ index bb91a0bcb..c00ab0023 100644
 @@ -121,7 +121,7 @@ function x265_pixel_sse_pp_32x32_neon
      veor.u8     q0, q0
      veor.u8     q1, q1
- 
+
 -.loop_sse_pp_32:
 +.Loop_sse_pp_32:
      subs        r12, #1
@@ -5641,7 +5506,7 @@ index bb91a0bcb..c00ab0023 100644
 @@ -154,7 +154,7 @@ function x265_pixel_sse_pp_64x64_neon
      veor.u8     q0, q0
      veor.u8     q1, q1
- 
+
 -.loop_sse_pp_64:
 +.Loop_sse_pp_64:
      subs        r12, #1
@@ -5659,7 +5524,7 @@ index bb91a0bcb..c00ab0023 100644
 @@ -257,7 +257,7 @@ function x265_pixel_sse_ss_16x16_neon
      veor.u8     q0, q0
      veor.u8     q1, q1
- 
+
 -.loop_sse_ss_16:
 +.Loop_sse_ss_16:
      subs        r12, #1
@@ -5677,7 +5542,7 @@ index bb91a0bcb..c00ab0023 100644
 @@ -286,7 +286,7 @@ function x265_pixel_sse_ss_32x32_neon
      veor.u8     q0, q0
      veor.u8     q1, q1
- 
+
 -.loop_sse_ss_32:
 +.Loop_sse_ss_32:
      subs        r12, #1
@@ -5695,7 +5560,7 @@ index bb91a0bcb..c00ab0023 100644
 @@ -324,7 +324,7 @@ function x265_pixel_sse_ss_64x64_neon
      veor.u8     q0, q0
      veor.u8     q1, q1
- 
+
 -.loop_sse_ss_64:
 +.Loop_sse_ss_64:
      subs        r12, #1
@@ -5713,7 +5578,7 @@ index bb91a0bcb..c00ab0023 100644
 @@ -417,7 +417,7 @@ function x265_pixel_ssd_s_16x16_neon
      veor.u8     q0, q0
      veor.u8     q1, q1
- 
+
 -.loop_ssd_s_16:
 +.Loop_ssd_s_16:
      subs        r12, #1
@@ -5731,7 +5596,7 @@ index bb91a0bcb..c00ab0023 100644
 @@ -446,7 +446,7 @@ function x265_pixel_ssd_s_32x32_neon
      veor.u8     q0, q0
      veor.u8     q1, q1
- 
+
 -.loop_ssd_s_32:
 +.Loop_ssd_s_32:
      subs        r12, #1
@@ -5753,7 +5618,7 @@ index 37c19ae72..43025df06 100644
 @@ -176,6 +176,12 @@ inline T x265_clip3(T minVal, T maxVal, T a) { return x265_min(x265_max(minVal,
  template<typename T> /* clip to pixel range, 0..255 or 0..1023 */
  inline pixel x265_clip(T x) { return (pixel)x265_min<T>(T((1 << X265_DEPTH) - 1), x265_max<T>(T(0), x)); }
- 
+
 +/* get the sign of input variable */
 +static inline int8_t x265_signOf(int32_t x)
 +{
@@ -5761,16 +5626,16 @@ index 37c19ae72..43025df06 100644
 +}
 +
  typedef int16_t  coeff_t;      // transform coefficient
- 
+
  #define X265_MIN(a, b) ((a) < (b) ? (a) : (b))
 diff --git a/source/common/loopfilter.cpp b/source/common/loopfilter.cpp
 index 8651390d2..f4cd65389 100644
 --- a/source/common/loopfilter.cpp
 +++ b/source/common/loopfilter.cpp
 @@ -30,16 +30,10 @@
- 
+
  namespace {
- 
+
 -/* get the sign of input variable (TODO: this is a dup, make common) */
 -inline int8_t signOf(int x)
 -{
@@ -5783,10 +5648,10 @@ index 8651390d2..f4cd65389 100644
 -        dst[x] = signOf(src1[x] - src2[x]);
 +        dst[x] = x265_signOf(src1[x] - src2[x]);
  }
- 
+
  static void processSaoCUE0(pixel * rec, int8_t * offsetEo, int width, int8_t* signLeft, intptr_t stride)
 @@ -70,7 +64,7 @@ static void processSaoCUE1(pixel* rec, int8_t* upBuff1, int8_t* offsetEo, intptr
- 
+
      for (x = 0; x < width; x++)
      {
 -        signDown = signOf(rec[x] - rec[x + stride]);
@@ -5813,7 +5678,7 @@ index 8651390d2..f4cd65389 100644
          bufft[x + 1] = -signDown;
          rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);;
 @@ -115,7 +109,7 @@ static void processSaoCUE3(pixel *rec, int8_t *upBuff1, int8_t *offsetEo, intptr
- 
+
      for (int x = startX + 1; x < endX; x++)
      {
 -        signDown = signOf(rec[x] - rec[x + stride]);
@@ -5828,7 +5693,7 @@ index 3cd074cfa..06e5732bd 100644
 @@ -266,10 +266,6 @@ int satd4(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t s
  {
      int satd = 0;
- 
+
 -#if ENABLE_ASSEMBLY && X265_ARCH_ARM64 && !HIGH_BIT_DEPTH
 -    pixelcmp_t satd_4x4 = x265_pixel_satd_4x4_neon;
 -#endif
@@ -5839,7 +5704,7 @@ index 3cd074cfa..06e5732bd 100644
 @@ -284,10 +280,6 @@ int satd8(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t s
  {
      int satd = 0;
- 
+
 -#if ENABLE_ASSEMBLY && X265_ARCH_ARM64 && !HIGH_BIT_DEPTH
 -    pixelcmp_t satd_8x4 = x265_pixel_satd_8x4_neon;
 -#endif
@@ -5853,7 +5718,7 @@ index 10e418884..56d4319bf 100644
 +++ b/source/common/primitives.cpp
 @@ -258,8 +258,8 @@ void x265_setup_primitives(x265_param *param)
              primitives.cu[i].intra_pred_allangs = NULL;
- 
+
  #if ENABLE_ASSEMBLY
 -#if X265_ARCH_X86
 -        setupInstrinsicPrimitives(primitives, param->cpuid);
@@ -5868,7 +5733,7 @@ index df1cae4b7..fd343f5fe 100644
 +++ b/source/common/primitives.h
 @@ -470,12 +470,9 @@ inline int partitionFromLog2Size(int log2Size)
  }
- 
+
  void setupCPrimitives(EncoderPrimitives &p);
 -void setupInstrinsicPrimitives(EncoderPrimitives &p, int cpuMask);
 +void setupIntrinsicPrimitives(EncoderPrimitives &p, int cpuMask);
@@ -5886,7 +5751,7 @@ index 855ea277f..d37f7ac3d 100644
 +++ b/source/common/vec/vec-primitives.cpp
 @@ -59,7 +59,7 @@ void setupIntrinsicDCT_ssse3(EncoderPrimitives&);
  void setupIntrinsicDCT_sse41(EncoderPrimitives&);
- 
+
  /* Use primitives for the best available vector architecture */
 -void setupInstrinsicPrimitives(EncoderPrimitives &p, int cpuMask)
 +void setupIntrinsicPrimitives(EncoderPrimitives &p, int cpuMask)
@@ -5900,7 +5765,7 @@ index 0c46ece53..105ec79de 100644
 @@ -36,12 +36,6 @@ inline int32_t roundIBDI(int32_t num, int32_t den)
      return num >= 0 ? ((num * 2 + den) / (den * 2)) : -((-num * 2 + den) / (den * 2));
  }
- 
+
 -/* get the sign of input variable (TODO: this is a dup, make common) */
 -inline int8_t signOf(int x)
 -{
@@ -5922,7 +5787,7 @@ index 0c46ece53..105ec79de 100644
 +                    int signRight = x265_signOf(rec[x] - rec[x + 1]);
                      int edgeType = signRight + signLeft + 2;
                      signLeft = -signRight;
- 
+
 @@ -343,8 +337,8 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
          {
              for (int y = 0; y < ctuHeight; y += 2, rec += 2 * stride)
@@ -5931,7 +5796,7 @@ index 0c46ece53..105ec79de 100644
 -                signLeft1[1] = signOf(rec[stride + startX] - tmpL[y + 1]);
 +                signLeft1[0] = x265_signOf(rec[startX] - tmpL[y]);
 +                signLeft1[1] = x265_signOf(rec[stride + startX] - tmpL[y + 1]);
- 
+
                  if (!lpelx)
                  {
 @@ -385,13 +379,13 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
@@ -5940,7 +5805,7 @@ index 0c46ece53..105ec79de 100644
              for (int x = 0; x < ctuWidth; x++)
 -                upBuff1[x] = signOf(rec[x] - tmpU[x]);
 +                upBuff1[x] = x265_signOf(rec[x] - tmpU[x]);
- 
+
              for (int y = startY; y < endY; y++, rec += stride)
              {
                  for (int x = 0; x < ctuWidth; x++)
@@ -5949,7 +5814,7 @@ index 0c46ece53..105ec79de 100644
 +                    int8_t signDown = x265_signOf(rec[x] - rec[x + stride]);
                      int edgeType = signDown + upBuff1[x] + 2;
                      upBuff1[x] = -signDown;
- 
+
 @@ -445,17 +439,17 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
          else
          {
@@ -5957,7 +5822,7 @@ index 0c46ece53..105ec79de 100644
 -                upBuff1[x] = signOf(rec[x] - tmpU[x - 1]);
 +                upBuff1[x] = x265_signOf(rec[x] - tmpU[x - 1]);
          }
- 
+
          if (ctuWidth & 15)
          {
               for (int y = startY; y < endY; y++, rec += stride)
@@ -5977,16 +5842,16 @@ index 0c46ece53..105ec79de 100644
              {
 -                int8_t iSignDown2 = signOf(rec[stride + startX] - tmpL[y]);
 +                int8_t iSignDown2 = x265_signOf(rec[stride + startX] - tmpL[y]);
- 
+
                  primitives.saoCuOrgE2[endX > 16](rec + startX, upBufft + startX, upBuff1 + startX, offsetEo, endX - startX, stride);
- 
+
 @@ -493,25 +487,25 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
          if (ctuWidth & 15)
          {
              for (int x = startX - 1; x < endX; x++)
 -                upBuff1[x] = signOf(rec[x] - tmpU[x + 1]);
 +                upBuff1[x] = x265_signOf(rec[x] - tmpU[x + 1]);
- 
+
              for (int y = startY; y < endY; y++, rec += stride)
              {
                  int x = startX;
@@ -5995,7 +5860,7 @@ index 0c46ece53..105ec79de 100644
                  int edgeType = signDown + upBuff1[x] + 2;
                  upBuff1[x - 1] = -signDown;
                  rec[x] = m_clipTable[rec[x] + offsetEo[edgeType]];
- 
+
                  for (x = startX + 1; x < endX; x++)
                  {
 -                    signDown = signOf(rec[x] - rec[x + stride - 1]);
@@ -6004,7 +5869,7 @@ index 0c46ece53..105ec79de 100644
                      upBuff1[x - 1] = -signDown;
                      rec[x] = m_clipTable[rec[x] + offsetEo[edgeType]];
                  }
- 
+
 -                upBuff1[endX - 1] = signOf(rec[endX - 1 + stride] - rec[endX]);
 +                upBuff1[endX - 1] = x265_signOf(rec[endX - 1 + stride] - rec[endX]);
              }
@@ -6012,13 +5877,13 @@ index 0c46ece53..105ec79de 100644
          else
 @@ -519,7 +513,7 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
              int8_t firstSign, lastSign;
- 
+
              if (lpelx)
 -                firstSign = signOf(rec[-1] - tmpU[0]);
 +                firstSign = x265_signOf(rec[-1] - tmpU[0]);
              if (rpelx == picWidth)
                  lastSign = upBuff1[ctuWidth - 1];
- 
+
 @@ -533,14 +527,14 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
              for (int y = startY; y < endY; y++, rec += stride)
              {
@@ -6028,14 +5893,14 @@ index 0c46ece53..105ec79de 100644
                  int edgeType = signDown + upBuff1[x] + 2;
                  upBuff1[x - 1] = -signDown;
                  rec[x] = m_clipTable[rec[x] + offsetEo[edgeType]];
- 
+
                  primitives.saoCuOrgE3[endX > 16](rec, upBuff1, offsetEo, stride - 1, startX, endX);
- 
+
 -                upBuff1[endX - 1] = signOf(rec[endX - 1 + stride] - rec[endX]);
 +                upBuff1[endX - 1] = x265_signOf(rec[endX - 1 + stride] - rec[endX]);
              }
          }
- 
+
 @@ -1030,10 +1024,10 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
              for (y = 0; y < ctuHeight; y++)
              {
@@ -6048,14 +5913,14 @@ index 0c46ece53..105ec79de 100644
 +                    int signRight = x265_signOf(rec[x] - rec[x + 1]);
                      int edgeType = signRight + signLeft + 2;
                      signLeft = -signRight;
- 
+
 @@ -1069,13 +1063,13 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
              }
- 
+
              for (x = startX; x < ctuWidth; x++)
 -                upBuff1[x] = signOf(rec[x] - rec[x - stride]);
 +                upBuff1[x] = x265_signOf(rec[x] - rec[x - stride]);
- 
+
              for (y = firstY; y < endY; y++)
              {
                  for (x = (y < startY - 1 ? startX : 0); x < ctuWidth; x++)
@@ -6064,14 +5929,14 @@ index 0c46ece53..105ec79de 100644
 +                    int signDown = x265_signOf(rec[x] - rec[x + stride]);
                      int edgeType = signDown + upBuff1[x] + 2;
                      upBuff1[x] = -signDown;
- 
+
 @@ -1117,15 +1111,15 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
              }
- 
+
              for (x = startX; x < endX; x++)
 -                upBuff1[x] = signOf(rec[x] - rec[x - stride - 1]);
 +                upBuff1[x] = x265_signOf(rec[x] - rec[x - stride - 1]);
- 
+
              for (y = firstY; y < endY; y++)
              {
                  x = (y < startY - 1 ? startX : firstX);
@@ -6083,14 +5948,14 @@ index 0c46ece53..105ec79de 100644
 +                    int signDown = x265_signOf(rec[x] - rec[x + stride + 1]);
                      int edgeType = signDown + upBuff1[x] + 2;
                      upBufft[x + 1] = -signDown;
- 
+
 @@ -1169,13 +1163,13 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
              }
- 
+
              for (x = startX - 1; x < endX; x++)
 -                upBuff1[x] = signOf(rec[x] - rec[x - stride + 1]);
 +                upBuff1[x] = x265_signOf(rec[x] - rec[x - stride + 1]);
- 
+
              for (y = firstY; y < endY; y++)
              {
                  for (x = (y < startY - 1 ? startX : firstX); x < endX; x++)
@@ -6099,18 +5964,18 @@ index 0c46ece53..105ec79de 100644
 +                    int signDown = x265_signOf(rec[x] - rec[x + stride - 1]);
                      int edgeType = signDown + upBuff1[x] + 2;
                      upBuff1[x - 1] = -signDown;
- 
+
 @@ -1186,7 +1180,7 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
                      count[s_eoTable[edgeType]]++;
                  }
- 
+
 -                upBuff1[endX - 1] = signOf(rec[endX - 1 + stride] - rec[endX]);
 +                upBuff1[endX - 1] = x265_signOf(rec[endX - 1 + stride] - rec[endX]);
- 
+
                  rec += stride;
                  fenc += stride;
 @@ -1789,11 +1783,11 @@ void saoCuStatsE0_c(const int16_t *diff, const pixel *rec, intptr_t stride, int
- 
+
      for (int y = 0; y < endY; y++)
      {
 -        int signLeft = signOf(rec[0] - rec[-1]);
@@ -6122,7 +5987,7 @@ index 0c46ece53..105ec79de 100644
 +            X265_CHECK(signRight == x265_signOf(rec[x] - rec[x + 1]), "signDown check failure\n");
              uint32_t edgeType = signRight + signLeft + 2;
              signLeft = -signRight;
- 
+
 @@ -1830,7 +1824,7 @@ void saoCuStatsE1_c(const int16_t *diff, const pixel *rec, intptr_t stride, int8
          for (int x = 0; x < endX; x++)
          {
@@ -6131,9 +5996,9 @@ index 0c46ece53..105ec79de 100644
 +            X265_CHECK(signDown == x265_signOf(rec[x] - rec[x + stride]), "signDown check failure\n");
              uint32_t edgeType = signDown + upBuff1[x] + 2;
              upBuff1[x] = (int8_t)(-signDown);
- 
+
 @@ -1862,11 +1856,11 @@ void saoCuStatsE2_c(const int16_t *diff, const pixel *rec, intptr_t stride, int8
- 
+
      for (int y = 0; y < endY; y++)
      {
 -        upBufft[0] = signOf(rec[stride] - rec[-1]);
@@ -6153,15 +6018,15 @@ index 0c46ece53..105ec79de 100644
 -            X265_CHECK(signDown == signOf(rec[x] - rec[x + stride - 1]), "signDown check failure\n");
 +            X265_CHECK(signDown == x265_signOf(rec[x] - rec[x + stride - 1]), "signDown check failure\n");
              X265_CHECK(abs(upBuff1[x]) <= 1, "upBuffer1 check failure\n");
- 
+
              uint32_t edgeType = signDown + upBuff1[x] + 2;
 @@ -1911,7 +1905,7 @@ void saoCuStatsE3_c(const int16_t *diff, const pixel *rec, intptr_t stride, int8
              tmp_count[edgeType]++;
          }
- 
+
 -        upBuff1[endX - 1] = signOf(rec[endX - 1 + stride] - rec[endX]);
 +        upBuff1[endX - 1] = x265_signOf(rec[endX - 1 + stride] - rec[endX]);
- 
+
          rec += stride;
          diff += MAX_CU_SIZE;
 diff --git a/source/test/pixelharness.cpp b/source/test/pixelharness.cpp
@@ -6171,17 +6036,17 @@ index 550521666..bc255eb12 100644
 @@ -1373,8 +1373,7 @@ bool PixelHarness::check_saoCuStatsE1_t(saoCuStatsE1_t ref, saoCuStatsE1_t opt)
          ref(sbuf2 + 1, pbuf3 + 1, stride, upBuff1_ref, endX, endY, stats_ref, count_ref);
          checked(opt, sbuf2 + 1, pbuf3 + 1, stride, upBuff1_vec, endX, endY, stats_vec, count_vec);
- 
+
 -        if (   memcmp(_upBuff1_ref, _upBuff1_vec, sizeof(_upBuff1_ref))
 -            || memcmp(stats_ref, stats_vec, sizeof(stats_ref))
 +        if (   memcmp(stats_ref, stats_vec, sizeof(stats_ref))
              || memcmp(count_ref, count_vec, sizeof(count_ref)))
              return false;
- 
+
 @@ -1425,10 +1424,7 @@ bool PixelHarness::check_saoCuStatsE2_t(saoCuStatsE2_t ref, saoCuStatsE2_t opt)
          ref(sbuf2 + 1, pbuf3 + 1, stride, upBuff1_ref, upBufft_ref, endX, endY, stats_ref, count_ref);
          checked(opt, sbuf2 + 1, pbuf3 + 1, stride, upBuff1_vec, upBufft_vec, endX, endY, stats_vec, count_vec);
- 
+
 -        // TODO: don't check upBuff*, the latest output pixels different, and can move into stack temporary buffer in future
 -        if (   memcmp(_upBuff1_ref, _upBuff1_vec, sizeof(_upBuff1_ref))
 -            || memcmp(_upBufft_ref, _upBufft_vec, sizeof(_upBufft_ref))
@@ -6189,17 +6054,17 @@ index 550521666..bc255eb12 100644
 +        if (   memcmp(stats_ref, stats_vec, sizeof(stats_ref))
              || memcmp(count_ref, count_vec, sizeof(count_ref)))
              return false;
- 
+
 @@ -1476,8 +1472,7 @@ bool PixelHarness::check_saoCuStatsE3_t(saoCuStatsE3_t ref, saoCuStatsE3_t opt)
          ref(sbuf2, pbuf3, stride, upBuff1_ref, endX, endY, stats_ref, count_ref);
          checked(opt, sbuf2, pbuf3, stride, upBuff1_vec, endX, endY, stats_vec, count_vec);
- 
+
 -        if (   memcmp(_upBuff1_ref, _upBuff1_vec, sizeof(_upBuff1_ref))
 -            || memcmp(stats_ref, stats_vec, sizeof(stats_ref))
 +        if (   memcmp(stats_ref, stats_vec, sizeof(stats_ref))
              || memcmp(count_ref, count_vec, sizeof(count_ref)))
              return false;
- 
+
 diff --git a/source/test/testbench.cpp b/source/test/testbench.cpp
 index ddcfd6139..45da893a7 100644
 --- a/source/test/testbench.cpp
@@ -6207,7 +6072,7 @@ index ddcfd6139..45da893a7 100644
 @@ -190,10 +190,10 @@ int main(int argc, char *argv[])
          else
              continue;
- 
+
 -#if X265_ARCH_X86
 +#if defined(X265_ARCH_X86) || defined(X265_ARCH_ARM64)
          EncoderPrimitives vecprim;
@@ -6218,7 +6083,7 @@ index ddcfd6139..45da893a7 100644
          for (size_t h = 0; h < sizeof(harness) / sizeof(TestHarness*); h++)
          {
 @@ -231,8 +231,8 @@ int main(int argc, char *argv[])
- 
+
      EncoderPrimitives optprim;
      memset(&optprim, 0, sizeof(optprim));
 -#if X265_ARCH_X86
@@ -6226,5 +6091,5 @@ index ddcfd6139..45da893a7 100644
 +#if defined(X265_ARCH_X86) || defined(X265_ARCH_ARM64)
 +    setupIntrinsicPrimitives(optprim, cpuid);
  #endif
- 
+
      setupAssemblyPrimitives(optprim, cpuid);

--- a/patches/50-x265/aarch64-optimisations.patch
+++ b/patches/50-x265/aarch64-optimisations.patch
@@ -1,0 +1,6230 @@
+diff --git a/build/README.txt b/build/README.txt
+index 6346eb041..af4abd21c 100644
+--- a/build/README.txt
++++ b/build/README.txt
+@@ -94,22 +94,23 @@ found, the version will be "unknown".
+ 
+ = Build Instructions for cross-compilation for Arm AArch64 Targets=
+ 
+-When the target platform is based on Arm AArch64 architecture, the x265 can be
+-built in x86 platforms. However, the CMAKE_C_COMPILER and CMAKE_CXX_COMPILER
+-enviroment variables should be set to point to the cross compilers of the
+-appropriate gcc. For example:
++Cross compilation of x265 for AArch64 targets is possible on x86 platforms by
++passing a toolchain file when running CMake to configure the project:
+ 
+-1. export CMAKE_C_COMPILER=aarch64-unknown-linux-gnu-gcc
+-2. export CMAKE_CXX_COMPILER=aarch64-unknown-linux-gnu-g++
++* cmake -DCMAKE_TOOLCHAIN_FILE=<path-to-toolchain-file>
+ 
+-The default ones are aarch64-linux-gnu-gcc and aarch64-linux-gnu-g++.
+-Then, the normal building process can be followed.
++Toolchain files for AArch64 cross-compilation exist in the /build directory.
++These specify a default cross-compiler to use; however this can be overridden
++by setting the CMAKE_C_COMPILER and CMAKE_CXX_COMPILER CMake variables when
++running CMake to configure the project. For example:
+ 
+-Moreover, if the target platform supports SVE or SVE2 instruction set, the
+-CROSS_COMPILE_SVE or CROSS_COMPILE_SVE2 environment variables should be set
+-to true, respectively. For example:
++* cmake -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++
+ 
+-1. export CROSS_COMPILE_SVE2=true
+-2. export CROSS_COMPILE_SVE=true
++Moreover, if the target platform supports SVE or SVE2, CROSS_COMPILE_SVE or
++CROSS_COMPILE_SVE2 CMake options should be set to ON, respectively.
++For example, when running CMake to configure the project:
+ 
+-Then, the normal building process can be followed.
++1. cmake -DCROSS_COMPILE_SVE=ON  <other configuration options...>
++2. cmake -DCROSS_COMPILE_SVE2=ON <other configuration options...>
++
++Then, the normal build process can be followed.
+diff --git a/build/aarch64-darwin/crosscompile.cmake b/build/aarch64-darwin/crosscompile.cmake
+index d933daaa2..6037d5ed6 100644
+--- a/build/aarch64-darwin/crosscompile.cmake
++++ b/build/aarch64-darwin/crosscompile.cmake
+@@ -7,17 +7,14 @@ set(CROSS_COMPILE_ARM64 1)
+ set(CMAKE_SYSTEM_NAME Darwin)
+ set(CMAKE_SYSTEM_PROCESSOR aarch64)
+ 
+-# specify the cross compiler
+-set(CMAKE_C_COMPILER gcc-12)
+-set(CMAKE_CXX_COMPILER g++-12)
++# specify the cross compiler (giving precedence to user-supplied CC/CXX)
++if(NOT DEFINED CMAKE_C_COMPILER)
++    set(CMAKE_C_COMPILER gcc)
++endif()
++if(NOT DEFINED CMAKE_CXX_COMPILER)
++    set(CMAKE_CXX_COMPILER g++)
++endif()
+ 
+ # specify the target environment
+ SET(CMAKE_FIND_ROOT_PATH  /opt/homebrew/bin/)
+ 
+-# specify whether SVE/SVE2 is supported by the target platform
+-if(DEFINED ENV{CROSS_COMPILE_SVE2})
+-    set(CROSS_COMPILE_SVE2 1)
+-elseif(DEFINED ENV{CROSS_COMPILE_SVE})
+-    set(CROSS_COMPILE_SVE 1)
+-endif()
+-
+diff --git a/build/aarch64-linux-clang/crosscompile.cmake b/build/aarch64-linux-clang/crosscompile.cmake
+new file mode 100644
+index 000000000..41c76e166
+--- /dev/null
++++ b/build/aarch64-linux-clang/crosscompile.cmake
+@@ -0,0 +1,25 @@
++# CMake toolchain file for cross compiling x265 for AArch64, using Clang.
++
++set(CROSS_COMPILE_ARM64 1)
++set(CMAKE_SYSTEM_NAME Linux)
++set(CMAKE_SYSTEM_PROCESSOR aarch64)
++
++set(TARGET_TRIPLE aarch64-linux-gnu)
++
++# specify the cross compiler (giving precedence to user-supplied CC/CXX)
++if(NOT DEFINED CMAKE_C_COMPILER)
++    set(CMAKE_C_COMPILER clang)
++endif()
++if(NOT DEFINED CMAKE_CXX_COMPILER)
++    set(CMAKE_CXX_COMPILER clang++)
++endif()
++
++# specify compiler target
++set(CMAKE_C_COMPILER_TARGET ${TARGET_TRIPLE})
++set(CMAKE_CXX_COMPILER_TARGET ${TARGET_TRIPLE})
++
++# specify assembler target
++list(APPEND ASM_FLAGS "--target=${TARGET_TRIPLE}")
++
++# specify the target environment
++SET(CMAKE_FIND_ROOT_PATH /usr/aarch64-linux-gnu)
+diff --git a/build/aarch64-linux/crosscompile.cmake b/build/aarch64-linux/crosscompile.cmake
+index 8cfe3243d..caf26af77 100644
+--- a/build/aarch64-linux/crosscompile.cmake
++++ b/build/aarch64-linux/crosscompile.cmake
+@@ -7,25 +7,14 @@ set(CROSS_COMPILE_ARM64 1)
+ set(CMAKE_SYSTEM_NAME Linux)
+ set(CMAKE_SYSTEM_PROCESSOR aarch64)
+ 
+-# specify the cross compiler
+-if(DEFINED ENV{CMAKE_C_COMPILER})
+-    set(CMAKE_C_COMPILER $ENV{CMAKE_C_COMPILER})
+-else()
++# specify the cross compiler (giving precedence to user-supplied CC/CXX)
++if(NOT DEFINED CMAKE_C_COMPILER)
+     set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+ endif()
+-if(DEFINED ENV{CMAKE_CXX_COMPILER})
+-    set(CMAKE_CXX_COMPILER $ENV{CMAKE_CXX_COMPILER})
+-else()
++if(NOT DEFINED CMAKE_CXX_COMPILER)
+     set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+ endif()
+ 
+ # specify the target environment
+ SET(CMAKE_FIND_ROOT_PATH  /usr/aarch64-linux-gnu)
+ 
+-# specify whether SVE/SVE2 is supported by the target platform
+-if(DEFINED ENV{CROSS_COMPILE_SVE2})
+-    set(CROSS_COMPILE_SVE2 1)
+-elseif(DEFINED ENV{CROSS_COMPILE_SVE})
+-    set(CROSS_COMPILE_SVE 1)
+-endif()
+-
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index ab5ddfeb7..bed98bb37 100755
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -22,6 +22,8 @@ include(CheckIncludeFiles)
+ include(CheckFunctionExists)
+ include(CheckSymbolExists)
+ include(CheckCXXCompilerFlag)
++include(CheckCSourceCompiles)
++include(CheckCXXSourceCompiles)
+ 
+ option(FPROFILE_GENERATE "Compile executable to generate usage data" OFF)
+ option(FPROFILE_USE "Compile executable using generated usage data" OFF)
+@@ -88,6 +90,10 @@ elseif(ARM64MATCH GREATER "-1")
+     message(STATUS "Detected ARM64 target processor")
+     set(ARM64 1)
+     add_definitions(-DX265_ARCH_ARM64=1 -DHAVE_NEON)
++
++    # Options for cross compiling AArch64 optional extensions
++    option(CROSS_COMPILE_SVE "Cross Compile for SVE Target" OFF)
++    option(CROSS_COMPILE_SVE2 "Cross Compile for SVE2 Target" OFF)
+ else()
+     message(STATUS "CMAKE_SYSTEM_PROCESSOR value `${CMAKE_SYSTEM_PROCESSOR}` is unknown")
+     message(STATUS "Please add this value near ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}")
+@@ -266,14 +272,21 @@ if(GCC)
+         if(CPU_HAS_SVE2 OR CROSS_COMPILE_SVE2)
+             message(STATUS "Found SVE2")
+ 	        set(ARM_ARGS -O3 -march=armv8-a+sve2 -fPIC -flax-vector-conversions)
++            set(CPU_HAS_SVE2 1)
++            # SVE2 implies Neon and SVE.
++            set(CPU_HAS_SVE 1)
++            set(CPU_HAS_NEON 1)
+             add_definitions(-DHAVE_SVE2)
+             add_definitions(-DHAVE_SVE)
+-            add_definitions(-DHAVE_NEON) # for NEON c/c++ primitives, as currently there is no implementation that use SVE2
++            add_definitions(-DHAVE_NEON)
+         elseif(CPU_HAS_SVE OR CROSS_COMPILE_SVE)
+             message(STATUS "Found SVE")
++            set(CPU_HAS_SVE 1)
++            # SVE implies Neon.
++            set(CPU_HAS_NEON 1)
+ 	        set(ARM_ARGS -O3 -march=armv8-a+sve -fPIC -flax-vector-conversions)
+             add_definitions(-DHAVE_SVE)
+-            add_definitions(-DHAVE_NEON) # for NEON c/c++ primitives, as currently there is no implementation that use SVE
++            add_definitions(-DHAVE_NEON)
+         elseif(CPU_HAS_NEON)
+             message(STATUS "Found NEON")
+             set(ARM_ARGS -fPIC -flax-vector-conversions)
+@@ -281,6 +294,28 @@ if(GCC)
+         else()
+             set(ARM_ARGS -fPIC -flax-vector-conversions)
+         endif()        
++        if(CPU_HAS_SVE)
++            set(SVE_HEADER_TEST "
++#ifndef __ARM_NEON_SVE_BRIDGE
++#error 1
++#endif
++#include <arm_sve.h>
++#include <arm_neon_sve_bridge.h>
++int main() { return 0; }")
++            set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
++            # CMAKE_REQUIRED_FLAGS requires a space-delimited string, whereas
++            # ARM_ARGS is defined and used elsewhere as a ;-list.
++            foreach(ARM_ARG ${ARM_ARGS})
++                string(APPEND CMAKE_REQUIRED_FLAGS " ${ARM_ARG}")
++            endforeach()
++            check_c_source_compiles("${SVE_HEADER_TEST}" SVE_HEADER_C_TEST_COMPILED)
++            check_cxx_source_compiles("${SVE_HEADER_TEST}" SVE_HEADER_CXX_TEST_COMPILED)
++            set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
++            if(SVE_HEADER_C_TEST_COMPILED AND SVE_HEADER_CXX_TEST_COMPILED)
++                add_definitions(-DHAVE_SVE_BRIDGE=1)
++                set(HAVE_SVE_BRIDGE 1)
++            endif()
++        endif()
+     endif()
+ 	if(ENABLE_PIC)
+ 	list(APPEND ARM_ARGS -DPIC)
+@@ -334,9 +369,11 @@ if(GCC)
+     if (CC_HAS_FAST_MATH)
+         add_definitions(-ffast-math)
+     endif()
+-    check_cxx_compiler_flag(-mstackrealign CC_HAS_STACK_REALIGN) 
+-    if (CC_HAS_STACK_REALIGN)
+-        add_definitions(-mstackrealign)
++    if (NOT (ARM64 OR CROSS_COMPILE_ARM64))
++        check_cxx_compiler_flag(-mstackrealign CC_HAS_STACK_REALIGN)
++        if (CC_HAS_STACK_REALIGN)
++            add_definitions(-mstackrealign)
++        endif()
+     endif()
+     # Disable exceptions. Reduce executable size, increase compability.
+     check_cxx_compiler_flag(-fno-exceptions CC_HAS_FNO_EXCEPTIONS_FLAG)
+diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
+index 184b94127..40c932966 100644
+--- a/source/common/CMakeLists.txt
++++ b/source/common/CMakeLists.txt
+@@ -103,7 +103,8 @@ if(ENABLE_ASSEMBLY AND (ARM64 OR CROSS_COMPILE_ARM64))
+         add_definitions(-DAUTO_VECTORIZE=1)
+     endif()
+ 
+-    set(C_SRCS asm-primitives.cpp pixel-prim.h pixel-prim.cpp filter-prim.h filter-prim.cpp dct-prim.h dct-prim.cpp loopfilter-prim.cpp loopfilter-prim.h intrapred-prim.cpp arm64-utils.cpp arm64-utils.h fun-decls.h)
++    set(C_SRCS_NEON asm-primitives.cpp pixel-prim.h pixel-prim.cpp filter-prim.h filter-prim.cpp dct-prim.h dct-prim.cpp loopfilter-prim.cpp loopfilter-prim.h intrapred-prim.cpp arm64-utils.cpp arm64-utils.h fun-decls.h sao-prim.cpp)
++    set(C_SRCS_SVE sao-prim-sve.cpp)
+     enable_language(ASM)
+ 
+     # add ARM assembly/intrinsic files here
+@@ -115,9 +116,16 @@ if(ENABLE_ASSEMBLY AND (ARM64 OR CROSS_COMPILE_ARM64))
+     set(ARM_ASMS "${A_SRCS}" CACHE INTERNAL "ARM Assembly Sources")
+     set(ARM_ASMS_SVE "${A_SRCS_SVE}" CACHE INTERNAL "ARM Assembly Sources that use SVE instruction set")
+     set(ARM_ASMS_SVE2 "${A_SRCS_SVE2}" CACHE INTERNAL "ARM Assembly Sources that use SVE2 instruction set")
+-    foreach(SRC ${C_SRCS})
++    foreach(SRC ${C_SRCS_NEON})
+         set(ASM_PRIMITIVES ${ASM_PRIMITIVES} aarch64/${SRC})
+     endforeach()
++
++    if(CPU_HAS_SVE AND HAVE_SVE_BRIDGE)
++        foreach(SRC ${C_SRCS_SVE})
++            set(ASM_PRIMITIVES ${ASM_PRIMITIVES} aarch64/${SRC})
++        endforeach()
++    endif()
++
+     source_group(Assembly FILES ${ASM_PRIMITIVES})
+ endif(ENABLE_ASSEMBLY AND (ARM64 OR CROSS_COMPILE_ARM64))
+ 
+diff --git a/source/common/aarch64/asm-primitives.cpp b/source/common/aarch64/asm-primitives.cpp
+index 8c46bfd21..bab34a493 100644
+--- a/source/common/aarch64/asm-primitives.cpp
++++ b/source/common/aarch64/asm-primitives.cpp
+@@ -689,6 +689,7 @@ extern "C" {
+ #include "dct-prim.h"
+ #include "loopfilter-prim.h"
+ #include "intrapred-prim.h"
++#include "sao-prim.h"
+ 
+ namespace X265_NS
+ {
+@@ -708,12 +709,6 @@ void interp_8tap_hv_pp_cpu(const pixel *src, intptr_t srcStride, pixel *dst, int
+ 
+ void setupNeonPrimitives(EncoderPrimitives &p)
+ {
+-    setupPixelPrimitives_neon(p);
+-    setupFilterPrimitives_neon(p);
+-    setupDCTPrimitives_neon(p);
+-    setupLoopFilterPrimitives_neon(p);
+-    setupIntraPrimitives_neon(p);
+-
+     ALL_CHROMA_420_PU(p2s[NONALIGNED], filterPixelToShort, neon);
+     ALL_CHROMA_422_PU(p2s[ALIGNED], filterPixelToShort, neon);
+     ALL_CHROMA_444_PU(p2s[ALIGNED], filterPixelToShort, neon);
+@@ -1083,14 +1078,6 @@ void setupNeonPrimitives(EncoderPrimitives &p)
+ #if defined(HAVE_SVE2) || defined(HAVE_SVE)
+ void setupSvePrimitives(EncoderPrimitives &p)
+ {
+-    // When these primitives will use SVE/SVE2 instructions set,
+-    // change the following definitions to point to the SVE/SVE2 implementation
+-    setupPixelPrimitives_neon(p);
+-    setupFilterPrimitives_neon(p);
+-    setupDCTPrimitives_neon(p);
+-    setupLoopFilterPrimitives_neon(p);
+-    setupIntraPrimitives_neon(p);
+-
+     CHROMA_420_PU_FILTER_PIXEL_TO_SHORT_NEON(p2s[NONALIGNED]);
+     CHROMA_420_PU_SVE_FILTER_PIXEL_TO_SHORT(p2s[NONALIGNED]);
+     CHROMA_422_PU_NEON_FILTER_PIXEL_TO_SHORT(p2s[ALIGNED]);
+@@ -1499,14 +1486,6 @@ void setupSvePrimitives(EncoderPrimitives &p)
+ #if defined(HAVE_SVE2)
+ void setupSve2Primitives(EncoderPrimitives &p)
+ {
+-    // When these primitives will use SVE/SVE2 instructions set,
+-    // change the following definitions to point to the SVE/SVE2 implementation
+-    setupPixelPrimitives_neon(p);
+-    setupFilterPrimitives_neon(p);
+-    setupDCTPrimitives_neon(p);
+-    setupLoopFilterPrimitives_neon(p);
+-    setupIntraPrimitives_neon(p);
+-
+     CHROMA_420_PU_FILTER_PIXEL_TO_SHORT_NEON(p2s[NONALIGNED]);
+     CHROMA_420_PU_SVE_FILTER_PIXEL_TO_SHORT(p2s[NONALIGNED]);
+     CHROMA_422_PU_NEON_FILTER_PIXEL_TO_SHORT(p2s[ALIGNED]);
+@@ -1961,4 +1940,24 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+ #endif
+ 
+ }
++
++void setupIntrinsicPrimitives(EncoderPrimitives &p, int cpuMask)
++{
++    if (cpuMask & X265_CPU_NEON)
++    {
++        setupPixelPrimitives_neon(p);
++        setupFilterPrimitives_neon(p);
++        setupDCTPrimitives_neon(p);
++        setupLoopFilterPrimitives_neon(p);
++        setupIntraPrimitives_neon(p);
++        setupSaoPrimitives_neon(p);
++    }
++#if defined(HAVE_SVE) && HAVE_SVE_BRIDGE
++    if (cpuMask & X265_CPU_SVE)
++    {
++        setupSaoPrimitives_sve(p);
++    }
++#endif
++}
++
+ } // namespace X265_NS
+diff --git a/source/common/aarch64/asm.S b/source/common/aarch64/asm.S
+index ce0668103..742978631 100644
+--- a/source/common/aarch64/asm.S
++++ b/source/common/aarch64/asm.S
+@@ -72,6 +72,16 @@
+ 
+ #define PFX_C(name)        JOIN(JOIN(JOIN(EXTERN_ASM, X265_NS), _), name)
+ 
++// Alignment of stack arguments of size less than 8 bytes.
++#ifdef __APPLE__
++#define STACK_ARG_ALIGNMENT 4
++#else
++#define STACK_ARG_ALIGNMENT 8
++#endif
++
++// Get offset from SP of stack argument at index `idx`.
++#define STACK_ARG_OFFSET(idx) (idx * STACK_ARG_ALIGNMENT)
++
+ #ifdef __APPLE__
+ .macro endfunc
+ ELF .size \name, . - \name
+@@ -184,4 +194,4 @@ ELF     .size   \name, . - \name
+     vtrn            \t3, \t4, \s3, \s4
+ .endm
+ 
+-#endif
+\ No newline at end of file
++#endif
+diff --git a/source/common/aarch64/blockcopy8-sve.S b/source/common/aarch64/blockcopy8-sve.S
+index 846927909..d5664af58 100644
+--- a/source/common/aarch64/blockcopy8-sve.S
++++ b/source/common/aarch64/blockcopy8-sve.S
+@@ -112,7 +112,7 @@ function PFX(blockcopy_sp_32x32_sve)
+     lsl             x3, x3, #1
+     movrel          x11, xtn_xtn2_table
+     ld1             {v31.16b}, [x11]
+-.loop_csp32_sve:
++.Loop_csp32_sve:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.8h-v3.8h}, [x2], x3
+@@ -124,7 +124,7 @@ function PFX(blockcopy_sp_32x32_sve)
+     st1             {v0.16b-v1.16b}, [x0], x1
+     st1             {v2.16b-v3.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_csp32_sve
++    cbnz            w12, .Loop_csp32_sve
+     ret
+ .vl_gt_16_blockcopy_sp_32_32:
+     cmp             x9, #48
+@@ -199,7 +199,7 @@ function PFX(blockcopy_ps_32x32_sve)
+     bgt             .vl_gt_16_blockcopy_ps_32_32
+     lsl             x1, x1, #1
+     mov             w12, #4
+-.loop_cps32_sve:
++.Loop_cps32_sve:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b-v17.16b}, [x2], x3
+@@ -215,7 +215,7 @@ function PFX(blockcopy_ps_32x32_sve)
+     st1             {v0.8h-v3.8h}, [x0], x1
+     st1             {v4.8h-v7.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_cps32_sve
++    cbnz            w12, .Loop_cps32_sve
+     ret
+ .vl_gt_16_blockcopy_ps_32_32:
+     cmp             x9, #48
+@@ -248,7 +248,7 @@ function PFX(blockcopy_ps_64x64_sve)
+     lsl             x1, x1, #1
+     sub             x1, x1, #64
+     mov             w12, #16
+-.loop_cps64_sve:
++.Loop_cps64_sve:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b-v19.16b}, [x2], x3
+@@ -263,7 +263,7 @@ function PFX(blockcopy_ps_64x64_sve)
+     st1             {v0.8h-v3.8h}, [x0], #64
+     st1             {v4.8h-v7.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_cps64_sve
++    cbnz            w12, .Loop_cps64_sve
+     ret
+ .vl_gt_16_blockcopy_ps_64_64:
+     cmp             x9, #48
+@@ -338,13 +338,13 @@ function PFX(blockcopy_ss_32x32_sve)
+     lsl             x1, x1, #1
+     lsl             x3, x3, #1
+     mov             w12, #4
+-.loop_css32_sve:
++.Loop_css32_sve:
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.8h-v3.8h}, [x2], x3
+     st1             {v0.8h-v3.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_css32_sve
++    cbnz            w12, .Loop_css32_sve
+     ret
+ .vl_gt_16_blockcopy_ss_32_32:
+     cmp             x9, #48
+@@ -379,7 +379,7 @@ function PFX(blockcopy_ss_64x64_sve)
+     lsl             x3, x3, #1
+     sub             x3, x3, #64
+     mov             w12, #8
+-.loop_css64_sve:
++.Loop_css64_sve:
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.8h-v3.8h}, [x2], #64
+@@ -387,7 +387,7 @@ function PFX(blockcopy_ss_64x64_sve)
+     st1             {v0.8h-v3.8h}, [x0], #64
+     st1             {v4.8h-v7.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_css64_sve
++    cbnz            w12, .Loop_css64_sve
+     ret
+ .vl_gt_16_blockcopy_ss_64_64:
+     cmp             x9, #48
+@@ -474,13 +474,13 @@ function PFX(blockcopy_ss_32x64_sve)
+     lsl             x1, x1, #1
+     lsl             x3, x3, #1
+     mov             w12, #8
+-.loop_css32x64_sve:
++.Loop_css32x64_sve:
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.8h-v3.8h}, [x2], x3
+     st1             {v0.8h-v3.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_css32x64_sve
++    cbnz            w12, .Loop_css32x64_sve
+     ret
+ .vl_gt_16_blockcopy_ss_32_64:
+     cmp             x9, #48
+@@ -570,7 +570,7 @@ function PFX(blockcopy_ps_32x64_sve)
+     bgt             .vl_gt_16_blockcopy_ps_32_64
+     lsl             x1, x1, #1
+     mov             w12, #8
+-.loop_cps32x64_sve:
++.Loop_cps32x64_sve:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b-v17.16b}, [x2], x3
+@@ -586,7 +586,7 @@ function PFX(blockcopy_ps_32x64_sve)
+     st1             {v0.8h-v3.8h}, [x0], x1
+     st1             {v4.8h-v7.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_cps32x64_sve
++    cbnz            w12, .Loop_cps32x64_sve
+     ret
+ .vl_gt_16_blockcopy_ps_32_64:
+     cmp             x9, #48
+@@ -730,13 +730,13 @@ function PFX(blockcopy_pp_32x\h\()_sve)
+     rdvl            x9, #1
+     cmp             x9, #16
+     bgt             .vl_gt_16_blockcopy_pp_32xN_\h
+-.loop_sve_32x\h\():
++.Loop_sve_32x\h\():
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.16b-v1.16b}, [x2], x3
+     st1             {v0.16b-v1.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_sve_32x\h
++    cbnz            w12, .Loop_sve_32x\h
+     ret
+ .vl_gt_16_blockcopy_pp_32xN_\h:
+     ptrue           p0.b, vl32
+@@ -765,13 +765,13 @@ function PFX(blockcopy_pp_64x\h\()_sve)
+     rdvl            x9, #1
+     cmp             x9, #16
+     bgt             .vl_gt_16_blockcopy_pp_64xN_\h
+-.loop_sve_64x\h\():
++.Loop_sve_64x\h\():
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v3.16b}, [x2], x3
+     st1             {v0.16b-v3.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_sve_64x\h
++    cbnz            w12, .Loop_sve_64x\h
+     ret
+ .vl_gt_16_blockcopy_pp_64xN_\h:
+     cmp             x9, #48
+@@ -856,7 +856,7 @@ function PFX(cpy2Dto1D_shl_16x16_sve)
+     bgt             .vl_gt_16_cpy2Dto1D_shl_16x16
+     cpy2Dto1D_shl_start_sve
+     mov             w12, #4
+-.loop_cpy2Dto1D_shl_16_sve:
++.Loop_cpy2Dto1D_shl_16_sve:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v2.16b-v3.16b}, [x1], x2
+@@ -864,7 +864,7 @@ function PFX(cpy2Dto1D_shl_16x16_sve)
+     sshl            v3.8h, v3.8h, v0.8h
+     st1             {v2.16b-v3.16b}, [x0], #32
+ .endr
+-    cbnz            w12, .loop_cpy2Dto1D_shl_16_sve
++    cbnz            w12, .Loop_cpy2Dto1D_shl_16_sve
+     ret
+ .vl_gt_16_cpy2Dto1D_shl_16x16:
+     ptrue           p0.h, vl16
+@@ -885,7 +885,7 @@ function PFX(cpy2Dto1D_shl_32x32_sve)
+     bgt             .vl_gt_16_cpy2Dto1D_shl_32x32
+     cpy2Dto1D_shl_start_sve
+     mov             w12, #16
+-.loop_cpy2Dto1D_shl_32_sve:
++.Loop_cpy2Dto1D_shl_32_sve:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.16b-v5.16b}, [x1], x2
+@@ -895,7 +895,7 @@ function PFX(cpy2Dto1D_shl_32x32_sve)
+     sshl            v5.8h, v5.8h, v0.8h
+     st1             {v2.16b-v5.16b}, [x0], #64
+ .endr
+-    cbnz            w12, .loop_cpy2Dto1D_shl_32_sve
++    cbnz            w12, .Loop_cpy2Dto1D_shl_32_sve
+     ret
+ .vl_gt_16_cpy2Dto1D_shl_32x32:
+     cmp             x9, #48
+@@ -931,7 +931,7 @@ function PFX(cpy2Dto1D_shl_64x64_sve)
+     cpy2Dto1D_shl_start_sve
+     mov             w12, #32
+     sub             x2, x2, #64
+-.loop_cpy2Dto1D_shl_64_sve:
++.Loop_cpy2Dto1D_shl_64_sve:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.16b-v5.16b}, [x1], #64
+@@ -947,7 +947,7 @@ function PFX(cpy2Dto1D_shl_64x64_sve)
+     st1             {v2.16b-v5.16b}, [x0], #64
+     st1             {v16.16b-v19.16b}, [x0], #64
+ .endr
+-    cbnz            w12, .loop_cpy2Dto1D_shl_64_sve
++    cbnz            w12, .Loop_cpy2Dto1D_shl_64_sve
+     ret
+ .vl_gt_16_cpy2Dto1D_shl_64x64:
+     dup             z0.h, w3
+@@ -1055,7 +1055,7 @@ function PFX(cpy2Dto1D_shr_32x32_sve)
+     bgt             .vl_gt_16_cpy2Dto1D_shr_32x32
+     cpy2Dto1D_shr_start
+     mov             w12, #16
+-.loop_cpy2Dto1D_shr_32_sve:
++.Loop_cpy2Dto1D_shr_32_sve:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.8h-v5.8h}, [x1], x2
+@@ -1069,7 +1069,7 @@ function PFX(cpy2Dto1D_shr_32x32_sve)
+     sshl            v5.8h, v5.8h, v0.8h
+     st1             {v2.8h-v5.8h}, [x0], #64
+ .endr
+-    cbnz            w12, .loop_cpy2Dto1D_shr_32_sve
++    cbnz            w12, .Loop_cpy2Dto1D_shr_32_sve
+     ret
+ .vl_gt_16_cpy2Dto1D_shr_32x32:
+     dup             z0.h, w3
+@@ -1218,7 +1218,7 @@ function PFX(cpy1Dto2D_shr_16x16_sve)
+     bgt             .vl_gt_16_cpy1Dto2D_shr_16x16
+     cpy1Dto2D_shr_start
+     mov             w12, #4
+-.loop_cpy1Dto2D_shr_16:
++.Loop_cpy1Dto2D_shr_16:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v2.8h-v3.8h}, [x1], #32
+@@ -1228,7 +1228,7 @@ function PFX(cpy1Dto2D_shr_16x16_sve)
+     sshl            v3.8h, v3.8h, v0.8h
+     st1             {v2.8h-v3.8h}, [x0], x2
+ .endr
+-    cbnz            w12, .loop_cpy1Dto2D_shr_16
++    cbnz            w12, .Loop_cpy1Dto2D_shr_16
+     ret
+ .vl_gt_16_cpy1Dto2D_shr_16x16:
+     dup             z0.h, w3
+@@ -1254,7 +1254,7 @@ function PFX(cpy1Dto2D_shr_32x32_sve)
+     bgt             .vl_gt_16_cpy1Dto2D_shr_32x32
+     cpy1Dto2D_shr_start
+     mov             w12, #16
+-.loop_cpy1Dto2D_shr_32_sve:
++.Loop_cpy1Dto2D_shr_32_sve:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.16b-v5.16b}, [x1], #64
+@@ -1268,7 +1268,7 @@ function PFX(cpy1Dto2D_shr_32x32_sve)
+     sshl            v5.8h, v5.8h, v0.8h
+     st1             {v2.16b-v5.16b}, [x0], x2
+ .endr
+-    cbnz            w12, .loop_cpy1Dto2D_shr_32_sve
++    cbnz            w12, .Loop_cpy1Dto2D_shr_32_sve
+     ret
+ .vl_gt_16_cpy1Dto2D_shr_32x32:
+     dup             z0.h, w3
+diff --git a/source/common/aarch64/blockcopy8.S b/source/common/aarch64/blockcopy8.S
+index 495ee7ea2..1ad371c57 100644
+--- a/source/common/aarch64/blockcopy8.S
++++ b/source/common/aarch64/blockcopy8.S
+@@ -86,7 +86,7 @@ function PFX(blockcopy_sp_32x32_neon)
+     lsl             x3, x3, #1
+     movrel          x11, xtn_xtn2_table
+     ld1             {v31.16b}, [x11]
+-.loop_csp32:
++.Loop_csp32:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.8h-v3.8h}, [x2], x3
+@@ -98,7 +98,7 @@ function PFX(blockcopy_sp_32x32_neon)
+     st1             {v0.16b-v1.16b}, [x0], x1
+     st1             {v2.16b-v3.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_csp32
++    cbnz            w12, .Loop_csp32
+     ret
+ endfunc
+ 
+@@ -108,7 +108,7 @@ function PFX(blockcopy_sp_64x64_neon)
+     sub             x3, x3, #64
+     movrel          x11, xtn_xtn2_table
+     ld1             {v31.16b}, [x11]
+-.loop_csp64:
++.Loop_csp64:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.8h-v3.8h}, [x2], #64
+@@ -119,7 +119,7 @@ function PFX(blockcopy_sp_64x64_neon)
+     tbl             v3.16b, {v6.16b,v7.16b}, v31.16b
+     st1             {v0.16b-v3.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_csp64
++    cbnz            w12, .Loop_csp64
+     ret
+ endfunc
+ 
+@@ -168,7 +168,7 @@ endfunc
+ function PFX(blockcopy_ps_32x32_neon)
+     lsl             x1, x1, #1
+     mov             w12, #4
+-.loop_cps32:
++.Loop_cps32:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b-v17.16b}, [x2], x3
+@@ -184,7 +184,7 @@ function PFX(blockcopy_ps_32x32_neon)
+     st1             {v0.8h-v3.8h}, [x0], x1
+     st1             {v4.8h-v7.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_cps32
++    cbnz            w12, .Loop_cps32
+     ret
+ endfunc
+ 
+@@ -192,7 +192,7 @@ function PFX(blockcopy_ps_64x64_neon)
+     lsl             x1, x1, #1
+     sub             x1, x1, #64
+     mov             w12, #16
+-.loop_cps64:
++.Loop_cps64:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b-v19.16b}, [x2], x3
+@@ -207,7 +207,7 @@ function PFX(blockcopy_ps_64x64_neon)
+     st1             {v0.8h-v3.8h}, [x0], #64
+     st1             {v4.8h-v7.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_cps64
++    cbnz            w12, .Loop_cps64
+     ret
+ endfunc
+ 
+@@ -252,13 +252,13 @@ function PFX(blockcopy_ss_32x32_neon)
+     lsl             x1, x1, #1
+     lsl             x3, x3, #1
+     mov             w12, #4
+-.loop_css32:
++.Loop_css32:
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.8h-v3.8h}, [x2], x3
+     st1             {v0.8h-v3.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_css32
++    cbnz            w12, .Loop_css32
+     ret
+ endfunc
+ 
+@@ -268,7 +268,7 @@ function PFX(blockcopy_ss_64x64_neon)
+     lsl             x3, x3, #1
+     sub             x3, x3, #64
+     mov             w12, #8
+-.loop_css64:
++.Loop_css64:
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.8h-v3.8h}, [x2], #64
+@@ -276,7 +276,7 @@ function PFX(blockcopy_ss_64x64_neon)
+     st1             {v0.8h-v3.8h}, [x0], #64
+     st1             {v4.8h-v7.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_css64
++    cbnz            w12, .Loop_css64
+     ret
+ endfunc
+ 
+@@ -321,13 +321,13 @@ function PFX(blockcopy_ss_32x64_neon)
+     lsl             x1, x1, #1
+     lsl             x3, x3, #1
+     mov             w12, #8
+-.loop_css32x64:
++.Loop_css32x64:
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.8h-v3.8h}, [x2], x3
+     st1             {v0.8h-v3.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_css32x64
++    cbnz            w12, .Loop_css32x64
+     ret
+ endfunc
+ 
+@@ -376,7 +376,7 @@ endfunc
+ function PFX(blockcopy_ps_32x64_neon)
+     lsl             x1, x1, #1
+     mov             w12, #8
+-.loop_cps32x64:
++.Loop_cps32x64:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b-v17.16b}, [x2], x3
+@@ -392,7 +392,7 @@ function PFX(blockcopy_ps_32x64_neon)
+     st1             {v0.8h-v3.8h}, [x0], x1
+     st1             {v4.8h-v7.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_cps32x64
++    cbnz            w12, .Loop_cps32x64
+     ret
+ endfunc
+ 
+@@ -443,7 +443,7 @@ function PFX(blockcopy_sp_32x64_neon)
+     lsl             x3, x3, #1
+     movrel          x11, xtn_xtn2_table
+     ld1             {v31.16b}, [x11]
+-.loop_csp32x64:
++.Loop_csp32x64:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.8h-v3.8h}, [x2], x3
+@@ -455,7 +455,7 @@ function PFX(blockcopy_sp_32x64_neon)
+     st1             {v0.16b-v1.16b}, [x0], x1
+     st1             {v2.16b-v3.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_csp32x64
++    cbnz            w12, .Loop_csp32x64
+     ret
+ endfunc
+ 
+@@ -595,13 +595,13 @@ blockcopy_pp_8xN_neon 32
+ 
+ function PFX(blockcopy_pp_8x64_neon)
+     mov             w12, #4
+-.loop_pp_8x64:
++.Loop_pp_8x64:
+     sub             w12, w12, #1
+ .rept 16
+     ld1             {v0.4h}, [x2], x3
+     st1             {v0.4h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_pp_8x64
++    cbnz            w12, .Loop_pp_8x64
+     ret
+ endfunc
+ 
+@@ -623,13 +623,13 @@ blockcopy_pp_16xN_neon 16
+ .macro blockcopy_pp_16xN1_neon h
+ function PFX(blockcopy_pp_16x\h\()_neon)
+     mov             w12, #\h / 8
+-.loop_16x\h\():
++.Loop_16x\h\():
+ .rept 8
+     ld1             {v0.8h}, [x2], x3
+     st1             {v0.8h}, [x0], x1
+ .endr
+     sub             w12, w12, #1
+-    cbnz            w12, .loop_16x\h
++    cbnz            w12, .Loop_16x\h
+     ret
+ endfunc
+ .endm
+@@ -651,38 +651,38 @@ endfunc
+ function PFX(blockcopy_pp_12x32_neon)
+     sub             x1, x1, #8
+     mov             w12, #4
+-.loop_pp_12x32:
++.Loop_pp_12x32:
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.16b}, [x2], x3
+     str             d0, [x0], #8
+     st1             {v0.s}[2], [x0], x1
+ .endr
+-    cbnz            w12, .loop_pp_12x32
++    cbnz            w12, .Loop_pp_12x32
+     ret
+ endfunc
+ 
+ function PFX(blockcopy_pp_24x32_neon)
+     mov             w12, #4
+-.loop_24x32:
++.Loop_24x32:
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.8b-v2.8b}, [x2], x3
+     st1             {v0.8b-v2.8b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_24x32
++    cbnz            w12, .Loop_24x32
+     ret
+ endfunc
+ 
+ function PFX(blockcopy_pp_24x64_neon)
+     mov             w12, #4
+-.loop_24x64:
++.Loop_24x64:
+     sub             w12, w12, #1
+ .rept 16
+     ld1             {v0.8b-v2.8b}, [x2], x3
+     st1             {v0.8b-v2.8b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_24x64
++    cbnz            w12, .Loop_24x64
+     ret
+ endfunc
+ 
+@@ -697,13 +697,13 @@ endfunc
+ .macro blockcopy_pp_32xN_neon h
+ function PFX(blockcopy_pp_32x\h\()_neon)
+     mov             w12, #\h / 8
+-.loop_32x\h\():
++.Loop_32x\h\():
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.16b-v1.16b}, [x2], x3
+     st1             {v0.16b-v1.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_32x\h
++    cbnz            w12, .Loop_32x\h
+     ret
+ endfunc
+ .endm
+@@ -716,26 +716,26 @@ blockcopy_pp_32xN_neon 48
+ 
+ function PFX(blockcopy_pp_48x64_neon)
+     mov             w12, #8
+-.loop_48x64:
++.Loop_48x64:
+     sub             w12, w12, #1
+ .rept 8
+     ld1             {v0.16b-v2.16b}, [x2], x3
+     st1             {v0.16b-v2.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_48x64
++    cbnz            w12, .Loop_48x64
+     ret
+ endfunc
+ 
+ .macro blockcopy_pp_64xN_neon h
+ function PFX(blockcopy_pp_64x\h\()_neon)
+     mov             w12, #\h / 4
+-.loop_64x\h\():
++.Loop_64x\h\():
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v3.16b}, [x2], x3
+     st1             {v0.16b-v3.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_64x\h
++    cbnz            w12, .Loop_64x\h
+     ret
+ endfunc
+ .endm
+@@ -950,11 +950,11 @@ function PFX(count_nonzero_32_neon)
+     trn1            v16.16b, v16.16b, v17.16b
+     movi            v18.16b, #0
+     mov             w12, #16
+-.loop_count_nonzero_32:
++.Loop_count_nonzero_32:
+     sub             w12, w12, #1
+     COUNT_NONZERO_8
+     add             v18.16b, v18.16b, v0.16b
+-    cbnz            w12, .loop_count_nonzero_32
++    cbnz            w12, .Loop_count_nonzero_32
+ 
+     uaddlv          s0, v18.8h
+     fmov            w0, s0
+@@ -994,7 +994,7 @@ endfunc
+ function PFX(cpy2Dto1D_shl_16x16_neon)
+     cpy2Dto1D_shl_start
+     mov             w12, #4
+-.loop_cpy2Dto1D_shl_16:
++.Loop_cpy2Dto1D_shl_16:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v2.16b-v3.16b}, [x1], x2
+@@ -1002,14 +1002,14 @@ function PFX(cpy2Dto1D_shl_16x16_neon)
+     sshl            v3.8h, v3.8h, v0.8h
+     st1             {v2.16b-v3.16b}, [x0], #32
+ .endr
+-    cbnz            w12, .loop_cpy2Dto1D_shl_16
++    cbnz            w12, .Loop_cpy2Dto1D_shl_16
+     ret
+ endfunc
+ 
+ function PFX(cpy2Dto1D_shl_32x32_neon)
+     cpy2Dto1D_shl_start
+     mov             w12, #16
+-.loop_cpy2Dto1D_shl_32:
++.Loop_cpy2Dto1D_shl_32:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.16b-v5.16b}, [x1], x2
+@@ -1019,7 +1019,7 @@ function PFX(cpy2Dto1D_shl_32x32_neon)
+     sshl            v5.8h, v5.8h, v0.8h
+     st1             {v2.16b-v5.16b}, [x0], #64
+ .endr
+-    cbnz            w12, .loop_cpy2Dto1D_shl_32
++    cbnz            w12, .Loop_cpy2Dto1D_shl_32
+     ret
+ endfunc
+ 
+@@ -1027,7 +1027,7 @@ function PFX(cpy2Dto1D_shl_64x64_neon)
+     cpy2Dto1D_shl_start
+     mov             w12, #32
+     sub             x2, x2, #64
+-.loop_cpy2Dto1D_shl_64:
++.Loop_cpy2Dto1D_shl_64:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.16b-v5.16b}, [x1], #64
+@@ -1043,7 +1043,7 @@ function PFX(cpy2Dto1D_shl_64x64_neon)
+     st1             {v2.16b-v5.16b}, [x0], #64
+     st1             {v16.16b-v19.16b}, [x0], #64
+ .endr
+-    cbnz            w12, .loop_cpy2Dto1D_shl_64
++    cbnz            w12, .Loop_cpy2Dto1D_shl_64
+     ret
+ endfunc
+ 
+@@ -1079,7 +1079,7 @@ endfunc
+ function PFX(cpy2Dto1D_shr_16x16_neon)
+     cpy2Dto1D_shr_start
+     mov             w12, #4
+-.loop_cpy2Dto1D_shr_16:
++.Loop_cpy2Dto1D_shr_16:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v2.8h-v3.8h}, [x1], x2
+@@ -1089,14 +1089,14 @@ function PFX(cpy2Dto1D_shr_16x16_neon)
+     sshl            v3.8h, v3.8h, v0.8h
+     st1             {v2.8h-v3.8h}, [x0], #32
+ .endr
+-    cbnz            w12, .loop_cpy2Dto1D_shr_16
++    cbnz            w12, .Loop_cpy2Dto1D_shr_16
+     ret
+ endfunc
+ 
+ function PFX(cpy2Dto1D_shr_32x32_neon)
+     cpy2Dto1D_shr_start
+     mov             w12, #16
+-.loop_cpy2Dto1D_shr_32:
++.Loop_cpy2Dto1D_shr_32:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.8h-v5.8h}, [x1], x2
+@@ -1110,7 +1110,7 @@ function PFX(cpy2Dto1D_shr_32x32_neon)
+     sshl            v5.8h, v5.8h, v0.8h
+     st1             {v2.8h-v5.8h}, [x0], #64
+ .endr
+-    cbnz            w12, .loop_cpy2Dto1D_shr_32
++    cbnz            w12, .Loop_cpy2Dto1D_shr_32
+     ret
+ endfunc
+ 
+@@ -1147,7 +1147,7 @@ endfunc
+ function PFX(cpy1Dto2D_shl_16x16_neon)
+     cpy1Dto2D_shl_start
+     mov             w12, #4
+-.loop_cpy1Dto2D_shl_16:
++.Loop_cpy1Dto2D_shl_16:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v2.16b-v3.16b}, [x1], #32
+@@ -1155,14 +1155,14 @@ function PFX(cpy1Dto2D_shl_16x16_neon)
+     sshl            v3.8h, v3.8h, v0.8h
+     st1             {v2.16b-v3.16b}, [x0], x2
+ .endr
+-    cbnz            w12, .loop_cpy1Dto2D_shl_16
++    cbnz            w12, .Loop_cpy1Dto2D_shl_16
+     ret
+ endfunc
+ 
+ function PFX(cpy1Dto2D_shl_32x32_neon)
+     cpy1Dto2D_shl_start
+     mov             w12, #16
+-.loop_cpy1Dto2D_shl_32:
++.Loop_cpy1Dto2D_shl_32:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.16b-v5.16b}, [x1], #64
+@@ -1172,7 +1172,7 @@ function PFX(cpy1Dto2D_shl_32x32_neon)
+     sshl            v5.8h, v5.8h, v0.8h
+     st1             {v2.16b-v5.16b}, [x0], x2
+ .endr
+-    cbnz            w12, .loop_cpy1Dto2D_shl_32
++    cbnz            w12, .Loop_cpy1Dto2D_shl_32
+     ret
+ endfunc
+ 
+@@ -1180,7 +1180,7 @@ function PFX(cpy1Dto2D_shl_64x64_neon)
+     cpy1Dto2D_shl_start
+     mov             w12, #32
+     sub             x2, x2, #64
+-.loop_cpy1Dto2D_shl_64:
++.Loop_cpy1Dto2D_shl_64:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.16b-v5.16b}, [x1], #64
+@@ -1196,7 +1196,7 @@ function PFX(cpy1Dto2D_shl_64x64_neon)
+     st1             {v2.16b-v5.16b}, [x0], #64
+     st1             {v16.16b-v19.16b}, [x0], x2
+ .endr
+-    cbnz            w12, .loop_cpy1Dto2D_shl_64
++    cbnz            w12, .Loop_cpy1Dto2D_shl_64
+     ret
+ endfunc
+ 
+@@ -1231,7 +1231,7 @@ endfunc
+ function PFX(cpy1Dto2D_shr_16x16_neon)
+     cpy1Dto2D_shr_start
+     mov             w12, #4
+-.loop_cpy1Dto2D_shr_16:
++.Loop_cpy1Dto2D_shr_16:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v2.8h-v3.8h}, [x1], #32
+@@ -1241,14 +1241,14 @@ function PFX(cpy1Dto2D_shr_16x16_neon)
+     sshl            v3.8h, v3.8h, v0.8h
+     st1             {v2.8h-v3.8h}, [x0], x2
+ .endr
+-    cbnz            w12, .loop_cpy1Dto2D_shr_16
++    cbnz            w12, .Loop_cpy1Dto2D_shr_16
+     ret
+ endfunc
+ 
+ function PFX(cpy1Dto2D_shr_32x32_neon)
+     cpy1Dto2D_shr_start
+     mov             w12, #16
+-.loop_cpy1Dto2D_shr_32:
++.Loop_cpy1Dto2D_shr_32:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.16b-v5.16b}, [x1], #64
+@@ -1262,7 +1262,7 @@ function PFX(cpy1Dto2D_shr_32x32_neon)
+     sshl            v5.8h, v5.8h, v0.8h
+     st1             {v2.16b-v5.16b}, [x0], x2
+ .endr
+-    cbnz            w12, .loop_cpy1Dto2D_shr_32
++    cbnz            w12, .Loop_cpy1Dto2D_shr_32
+     ret
+ endfunc
+ 
+@@ -1270,7 +1270,7 @@ function PFX(cpy1Dto2D_shr_64x64_neon)
+     cpy1Dto2D_shr_start
+     mov             w12, #32
+     sub             x2, x2, #64
+-.loop_cpy1Dto2D_shr_64:
++.Loop_cpy1Dto2D_shr_64:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v2.16b-v5.16b}, [x1], #64
+@@ -1294,6 +1294,6 @@ function PFX(cpy1Dto2D_shr_64x64_neon)
+     st1             {v2.16b-v5.16b}, [x0], #64
+     st1             {v16.16b-v19.16b}, [x0], x2
+ .endr
+-    cbnz            w12, .loop_cpy1Dto2D_shr_64
++    cbnz            w12, .Loop_cpy1Dto2D_shr_64
+     ret
+ endfunc
+diff --git a/source/common/aarch64/fun-decls.h b/source/common/aarch64/fun-decls.h
+index 1a1f3b489..ec17deda2 100644
+--- a/source/common/aarch64/fun-decls.h
++++ b/source/common/aarch64/fun-decls.h
+@@ -155,69 +155,69 @@ DECLS(sve);
+ DECLS(sve2);
+ 
+ 
+-void x265_pixel_planecopy_cp_neon(const uint8_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int width, int height, int shift);
++void PFX(pixel_planecopy_cp_neon(const uint8_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int width, int height, int shift));
+ 
+-uint64_t x265_pixel_var_8x8_neon(const pixel* pix, intptr_t stride);
+-uint64_t x265_pixel_var_16x16_neon(const pixel* pix, intptr_t stride);
+-uint64_t x265_pixel_var_32x32_neon(const pixel* pix, intptr_t stride);
+-uint64_t x265_pixel_var_64x64_neon(const pixel* pix, intptr_t stride);
++uint64_t PFX(pixel_var_8x8_neon(const pixel* pix, intptr_t stride));
++uint64_t PFX(pixel_var_16x16_neon(const pixel* pix, intptr_t stride));
++uint64_t PFX(pixel_var_32x32_neon(const pixel* pix, intptr_t stride));
++uint64_t PFX(pixel_var_64x64_neon(const pixel* pix, intptr_t stride));
+ 
+-void x265_getResidual4_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
+-void x265_getResidual8_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
+-void x265_getResidual16_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
+-void x265_getResidual32_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
++void PFX(getResidual4_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
++void PFX(getResidual8_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
++void PFX(getResidual16_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
++void PFX(getResidual32_neon(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
+ 
+-void x265_scale1D_128to64_neon(pixel *dst, const pixel *src);
+-void x265_scale2D_64to32_neon(pixel* dst, const pixel* src, intptr_t stride);
++void PFX(scale1D_128to64_neon(pixel *dst, const pixel *src));
++void PFX(scale2D_64to32_neon(pixel* dst, const pixel* src, intptr_t stride));
+ 
+-int x265_pixel_satd_4x4_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_4x8_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_4x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_4x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_8x4_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_8x8_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_8x12_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_8x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_8x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_8x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_12x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_12x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_16x4_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_16x8_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_16x12_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_16x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_16x24_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_16x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_16x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_24x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_24x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_32x8_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_32x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_32x24_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_32x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_32x48_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_32x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_48x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_64x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_64x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_64x48_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_64x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int PFX(pixel_satd_4x4_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_4x8_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_4x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_4x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_8x4_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_8x8_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_8x12_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_8x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_8x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_8x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_12x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_12x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_16x4_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_16x8_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_16x12_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_16x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_16x24_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_16x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_16x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_24x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_24x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_32x8_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_32x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_32x24_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_32x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_32x48_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_32x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_48x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_64x16_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_64x32_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_64x48_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_64x64_neon(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
+ 
+-int x265_pixel_sa8d_8x8_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
+-int x265_pixel_sa8d_8x16_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
+-int x265_pixel_sa8d_16x16_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
+-int x265_pixel_sa8d_16x32_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
+-int x265_pixel_sa8d_32x32_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
+-int x265_pixel_sa8d_32x64_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
+-int x265_pixel_sa8d_64x64_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2);
++int PFX(pixel_sa8d_8x8_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
++int PFX(pixel_sa8d_8x16_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
++int PFX(pixel_sa8d_16x16_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
++int PFX(pixel_sa8d_16x32_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
++int PFX(pixel_sa8d_32x32_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
++int PFX(pixel_sa8d_32x64_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
++int PFX(pixel_sa8d_64x64_neon(const pixel* pix1, intptr_t i_pix1, const pixel* pix2, intptr_t i_pix2));
+ 
+ uint32_t PFX(quant_neon)(const int16_t* coef, const int32_t* quantCoeff, int32_t* deltaU, int16_t* qCoef, int qBits, int add, int numCoeff);
+ uint32_t PFX(nquant_neon)(const int16_t* coef, const int32_t* quantCoeff, int16_t* qCoef, int qBits, int add, int numCoeff);
+ 
+-void x265_dequant_scaling_neon(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift);
+-void x265_dequant_normal_neon(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift);
++void PFX(dequant_scaling_neon(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift));
++void PFX(dequant_normal_neon(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift));
+ 
+-void x265_ssim_4x4x2_core_neon(const pixel* pix1, intptr_t stride1, const pixel* pix2, intptr_t stride2, int sums[2][4]);
++void PFX(ssim_4x4x2_core_neon(const pixel* pix1, intptr_t stride1, const pixel* pix2, intptr_t stride2, int sums[2][4]));
+ 
+ int PFX(psyCost_4x4_neon)(const pixel* source, intptr_t sstride, const pixel* recon, intptr_t rstride);
+ int PFX(psyCost_8x8_neon)(const pixel* source, intptr_t sstride, const pixel* recon, intptr_t rstride);
+@@ -226,30 +226,30 @@ void PFX(weight_sp_neon)(const int16_t* src, pixel* dst, intptr_t srcStride, int
+ int PFX(scanPosLast_neon)(const uint16_t *scan, const coeff_t *coeff, uint16_t *coeffSign, uint16_t *coeffFlag, uint8_t *coeffNum, int numSig, const uint16_t* scanCG4x4, const int trSize);
+ uint32_t PFX(costCoeffNxN_neon)(const uint16_t *scan, const coeff_t *coeff, intptr_t trSize, uint16_t *absCoeff, const uint8_t *tabSigCtx, uint32_t scanFlagMask, uint8_t *baseCtx, int offset, int scanPosSigOff, int subPosBase);
+ 
+-uint64_t x265_pixel_var_8x8_sve2(const pixel* pix, intptr_t stride);
+-uint64_t x265_pixel_var_16x16_sve2(const pixel* pix, intptr_t stride);
+-uint64_t x265_pixel_var_32x32_sve2(const pixel* pix, intptr_t stride);
+-uint64_t x265_pixel_var_64x64_sve2(const pixel* pix, intptr_t stride);
++uint64_t PFX(pixel_var_8x8_sve2(const pixel* pix, intptr_t stride));
++uint64_t PFX(pixel_var_16x16_sve2(const pixel* pix, intptr_t stride));
++uint64_t PFX(pixel_var_32x32_sve2(const pixel* pix, intptr_t stride));
++uint64_t PFX(pixel_var_64x64_sve2(const pixel* pix, intptr_t stride));
+ 
+-void x265_getResidual16_sve2(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
+-void x265_getResidual32_sve2(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride);
++void PFX(getResidual16_sve2(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
++void PFX(getResidual32_sve2(const pixel* fenc, const pixel* pred, int16_t* residual, intptr_t stride));
+ 
+-void x265_scale1D_128to64_sve2(pixel *dst, const pixel *src);
+-void x265_scale2D_64to32_sve2(pixel* dst, const pixel* src, intptr_t stride);
++void PFX(scale1D_128to64_sve2(pixel *dst, const pixel *src));
++void PFX(scale2D_64to32_sve2(pixel* dst, const pixel* src, intptr_t stride));
+ 
+-int x265_pixel_satd_4x4_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_8x4_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_8x12_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_32x16_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_32x32_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
+-int x265_pixel_satd_64x48_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2);
++int PFX(pixel_satd_4x4_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_8x4_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_8x12_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_32x16_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_32x32_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
++int PFX(pixel_satd_64x48_sve(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t stride_pix2));
+ 
+ uint32_t PFX(quant_sve)(const int16_t* coef, const int32_t* quantCoeff, int32_t* deltaU, int16_t* qCoef, int qBits, int add, int numCoeff);
+ 
+-void x265_dequant_scaling_sve2(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift);
+-void x265_dequant_normal_sve2(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift);
++void PFX(dequant_scaling_sve2(const int16_t* quantCoef, const int32_t* deQuantCoef, int16_t* coef, int num, int per, int shift));
++void PFX(dequant_normal_sve2(const int16_t* quantCoef, int16_t* coef, int num, int scale, int shift));
+ 
+-void x265_ssim_4x4x2_core_sve2(const pixel* pix1, intptr_t stride1, const pixel* pix2, intptr_t stride2, int sums[2][4]);
++void PFX(ssim_4x4x2_core_sve2(const pixel* pix1, intptr_t stride1, const pixel* pix2, intptr_t stride2, int sums[2][4]));
+ 
+ int PFX(psyCost_8x8_sve2)(const pixel* source, intptr_t sstride, const pixel* recon, intptr_t rstride);
+ void PFX(weight_sp_sve2)(const int16_t* src, pixel* dst, intptr_t srcStride, intptr_t dstStride, int width, int height, int w0, int round, int shift, int offset);
+diff --git a/source/common/aarch64/ipfilter-common.S b/source/common/aarch64/ipfilter-common.S
+index b7c61ee64..a08c3c165 100644
+--- a/source/common/aarch64/ipfilter-common.S
++++ b/source/common/aarch64/ipfilter-common.S
+@@ -800,10 +800,10 @@
+     mov             w12, #32
+     dup             v31.8h, w12
+     qpel_start_\v
+-.loop_luma_vpp_\v\()_\w\()x\h:
++.Loop_luma_vpp_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_luma_vpp_w8_\v\()_\w\()x\h:
++.Loop_luma_vpp_w8_\v\()_\w\()x\h:
+     add             x6, x0, x9
+ .if \w == 8 || \w == 24
+     qpel_load_32b \v
+@@ -833,11 +833,11 @@
+     add             x9, x9, #16
+ .endif
+     cmp             x9, #\w
+-    blt             .loop_luma_vpp_w8_\v\()_\w\()x\h
++    blt             .Loop_luma_vpp_w8_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_luma_vpp_\v\()_\w\()x\h
++    cbnz            x5, .Loop_luma_vpp_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+@@ -854,10 +854,10 @@
+     mov             w12, #8192
+     dup             v31.8h, w12
+     qpel_start_\v
+-.loop_ps_\v\()_\w\()x\h:
++.Loop_ps_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_ps_w8_\v\()_\w\()x\h:
++.Loop_ps_w8_\v\()_\w\()x\h:
+     add             x6, x0, x9
+ .if \w == 8 || \w == 24
+     qpel_load_32b \v
+@@ -885,11 +885,11 @@
+     add             x9, x9, #16
+ .endif
+     cmp             x9, #\w
+-    blt             .loop_ps_w8_\v\()_\w\()x\h
++    blt             .Loop_ps_w8_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_ps_\v\()_\w\()x\h
++    cbnz            x5, .Loop_ps_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+@@ -914,10 +914,10 @@
+     mov             x12, #\w
+     lsl             x12, x12, #1
+     qpel_start_\v\()_1
+-.loop_luma_vsp_\v\()_\w\()x\h:
++.Loop_luma_vsp_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_luma_vsp_w8_\v\()_\w\()x\h:
++.Loop_luma_vsp_w8_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_load_64b \v
+     qpel_filter_\v\()_32b_1
+@@ -933,11 +933,11 @@
+     add             x9, x9, #8
+ .endif
+     cmp             x9, x12
+-    blt             .loop_luma_vsp_w8_\v\()_\w\()x\h
++    blt             .Loop_luma_vsp_w8_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_luma_vsp_\v\()_\w\()x\h
++    cbnz            x5, .Loop_luma_vsp_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+@@ -957,10 +957,10 @@
+     mov             x12, #\w
+     lsl             x12, x12, #1
+     qpel_start_\v\()_1
+-.loop_luma_vss_\v\()_\w\()x\h:
++.Loop_luma_vss_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_luma_vss_w8_\v\()_\w\()x\h:
++.Loop_luma_vss_w8_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_load_64b \v
+     qpel_filter_\v\()_32b_1
+@@ -981,11 +981,11 @@
+ .endif
+ .endif
+     cmp             x9, x12
+-    blt             .loop_luma_vss_w8_\v\()_\w\()x\h
++    blt             .Loop_luma_vss_w8_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_luma_vss_\v\()_\w\()x\h
++    cbnz            x5, .Loop_luma_vss_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+@@ -1013,11 +1013,11 @@
+ .endr
+     ret
+ .else
+-.loop1_hpp_\v\()_\w\()x\h:
++.Loop1_hpp_\v\()_\w\()x\h:
+     mov             x7, #\w
+     mov             x11, x0
+     sub             x11, x11, #4
+-.loop2_hpp_\v\()_\w\()x\h:
++.Loop2_hpp_\v\()_\w\()x\h:
+     vextin8 \v
+     qpel_filter_\v\()_32b
+     hpp_end
+@@ -1031,11 +1031,11 @@
+     str             s17, [x2], #4
+     sub             x7, x7, #4
+ .endif
+-    cbnz            x7, .loop2_hpp_\v\()_\w\()x\h
++    cbnz            x7, .Loop2_hpp_\v\()_\w\()x\h
+     sub             x6, x6, #1
+     add             x0, x0, x1
+     add             x2, x2, x3
+-    cbnz            x6, .loop1_hpp_\v\()_\w\()x\h
++    cbnz            x6, .Loop1_hpp_\v\()_\w\()x\h
+     ret
+ .endif
+ .endm
+@@ -1051,7 +1051,7 @@
+     dup             v31.8h, w12
+     qpel_start_\v
+ .if \w == 4
+-.loop_hps_\v\()_\w\()x\h\():
++.Loop_hps_\v\()_\w\()x\h\():
+     mov             x11, x0
+     sub             x11, x11, #4
+     vextin8 \v
+@@ -1061,14 +1061,14 @@
+     sub             w6, w6, #1
+     add             x0, x0, x1
+     add             x2, x2, x3
+-    cbnz            w6, .loop_hps_\v\()_\w\()x\h
++    cbnz            w6, .Loop_hps_\v\()_\w\()x\h
+     ret
+ .else
+-.loop1_hps_\v\()_\w\()x\h\():
++.Loop1_hps_\v\()_\w\()x\h\():
+     mov             w7, #\w
+     mov             x11, x0
+     sub             x11, x11, #4
+-.loop2_hps_\v\()_\w\()x\h\():
++.Loop2_hps_\v\()_\w\()x\h\():
+ .if \w == 8 || \w == 12 || \w == 24
+     vextin8 \v
+     qpel_filter_\v\()_32b
+@@ -1092,11 +1092,11 @@
+     sub             w7, w7, #16
+     sub             x11, x11, #16
+ .endif
+-    cbnz            w7, .loop2_hps_\v\()_\w\()x\h
++    cbnz            w7, .Loop2_hps_\v\()_\w\()x\h
+     sub             w6, w6, #1
+     add             x0, x0, x1
+     add             x2, x2, x3
+-    cbnz            w6, .loop1_hps_\v\()_\w\()x\h
++    cbnz            w6, .Loop1_hps_\v\()_\w\()x\h
+     ret
+ .endif
+ .endm
+@@ -1107,10 +1107,10 @@
+     dup             v31.8h, w12
+     sub             x0, x0, x1
+     mov             x5, #\h
+-.loop_chroma_vpp_\v\()_\w\()x\h:
++.Loop_chroma_vpp_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_chroma_vpp_w8_\v\()_\w\()x\h:
++.Loop_chroma_vpp_w8_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_chroma_load_32b \v
+     qpel_filter_chroma_\v\()_32b
+@@ -1137,11 +1137,11 @@
+     str             d17, [x7], #8
+ .endif
+     cmp             x9, #\w
+-    blt             .loop_chroma_vpp_w8_\v\()_\w\()x\h
++    blt             .Loop_chroma_vpp_w8_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_chroma_vpp_\v\()_\w\()x\h
++    cbnz            x5, .Loop_chroma_vpp_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+@@ -1152,10 +1152,10 @@
+     lsl             x3, x3, #1
+     sub             x0, x0, x1
+     mov             x5, #\h
+-.loop_vps_\v\()_\w\()x\h:
++.Loop_vps_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_vps_w8_\v\()_\w\()x\h:
++.Loop_vps_w8_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_chroma_load_32b \v
+     qpel_filter_chroma_\v\()_32b
+@@ -1180,12 +1180,12 @@
+     str             q17, [x7], #16
+ .endif
+     cmp             x9, #\w
+-    blt             .loop_vps_w8_\v\()_\w\()x\h
++    blt             .Loop_vps_w8_\v\()_\w\()x\h
+ 
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_vps_\v\()_\w\()x\h
++    cbnz            x5, .Loop_vps_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+@@ -1200,10 +1200,10 @@
+     mov             x12, #\w
+     lsl             x12, x12, #1
+     qpel_start_chroma_\v\()_1
+-.loop_vsp_\v\()_\w\()x\h:
++.Loop_vsp_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_vsp_w8_\v\()_\w\()x\h:
++.Loop_vsp_w8_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_chroma_load_64b \v
+     qpel_filter_chroma_\v\()_32b_1
+@@ -1223,11 +1223,11 @@
+     str             d17, [x7], #8
+ .endif
+     cmp             x9, x12
+-    blt             .loop_vsp_w8_\v\()_\w\()x\h
++    blt             .Loop_vsp_w8_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_vsp_\v\()_\w\()x\h
++    cbnz            x5, .Loop_vsp_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+@@ -1239,7 +1239,7 @@
+     mov             x12, #\w
+     lsl             x12, x12, #1
+     qpel_start_chroma_\v\()_1
+-.loop_vss_\v\()_\w\()x\h:
++.Loop_vss_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+ .if \w == 4
+@@ -1252,7 +1252,7 @@
+     add             x9, x9, #4
+ .endr
+ .else
+-.loop_vss_w8_\v\()_\w\()x\h:
++.Loop_vss_w8_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_chroma_load_64b \v
+     qpel_filter_chroma_\v\()_32b_1
+@@ -1268,12 +1268,12 @@
+     add             x9, x9, #8
+ .endif
+     cmp             x9, x12
+-    blt             .loop_vss_w8_\v\()_\w\()x\h
++    blt             .Loop_vss_w8_\v\()_\w\()x\h
+ .endif
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_vss_\v\()_\w\()x\h
++    cbnz            x5, .Loop_vss_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+@@ -1284,7 +1284,7 @@
+     mov             w6, #\h
+     sub             x3, x3, #\w
+ .if \w == 2 || \w == 4 || \w == 6 || \w == 12
+-.loop4_chroma_hpp_\v\()_\w\()x\h:
++.Loop4_chroma_hpp_\v\()_\w\()x\h:
+     mov             x11, x0
+     sub             x11, x11, #2
+     vextin8_chroma \v
+@@ -1310,15 +1310,15 @@
+     sub             w6, w6, #1
+     add             x0, x0, x1
+     add             x2, x2, x3
+-    cbnz            w6, .loop4_chroma_hpp_\v\()_\w\()x\h
++    cbnz            w6, .Loop4_chroma_hpp_\v\()_\w\()x\h
+     ret
+ .else
+-.loop2_chroma_hpp_\v\()_\w\()x\h:
++.Loop2_chroma_hpp_\v\()_\w\()x\h:
+     mov             x7, #\w
+     lsr             x7, x7, #3
+     mov             x11, x0
+     sub             x11, x11, #2
+-.loop3_chroma_hpp_\v\()_\w\()x\h:
++.Loop3_chroma_hpp_\v\()_\w\()x\h:
+ .if \w == 8 || \w == 24
+     vextin8_chroma \v
+     qpel_filter_chroma_\v\()_32b
+@@ -1336,11 +1336,11 @@
+     sub             x7, x7, #2
+     sub             x11, x11, #16
+ .endif
+-    cbnz            x7, .loop3_chroma_hpp_\v\()_\w\()x\h
++    cbnz            x7, .Loop3_chroma_hpp_\v\()_\w\()x\h
+     sub             w6, w6, #1
+     add             x0, x0, x1
+     add             x2, x2, x3
+-    cbnz            w6, .loop2_chroma_hpp_\v\()_\w\()x\h
++    cbnz            w6, .Loop2_chroma_hpp_\v\()_\w\()x\h
+     ret
+ .endif
+ .endm
+@@ -1397,12 +1397,12 @@
+     add             w10, w10, #3
+ 9:
+     mov             w6, w10
+-.loop1_chroma_hps_\v\()_\w\()x\h\():
++.Loop1_chroma_hps_\v\()_\w\()x\h\():
+     mov             x7, #\w
+     lsr             x7, x7, #3
+     mov             x11, x0
+     sub             x11, x11, #2
+-.loop2_chroma_hps_\v\()_\w\()x\h\():
++.Loop2_chroma_hps_\v\()_\w\()x\h\():
+ .if \w == 8 || \w == 24
+     vextin8_chroma \v
+     qpel_filter_chroma_\v\()_32b
+@@ -1419,11 +1419,11 @@
+     sub             x7, x7, #2
+     sub             x11, x11, #16
+ .endif
+-    cbnz            x7, .loop2_chroma_hps_\v\()_\w\()x\h\()
++    cbnz            x7, .Loop2_chroma_hps_\v\()_\w\()x\h\()
+     sub             w6, w6, #1
+     add             x0, x0, x1
+     add             x2, x2, x3
+-    cbnz            w6, .loop1_chroma_hps_\v\()_\w\()x\h\()
++    cbnz            w6, .Loop1_chroma_hps_\v\()_\w\()x\h\()
+     ret
+ .endif
+ .endm
+diff --git a/source/common/aarch64/ipfilter-sve2.S b/source/common/aarch64/ipfilter-sve2.S
+index 95657db55..ab0ad2fae 100644
+--- a/source/common/aarch64/ipfilter-sve2.S
++++ b/source/common/aarch64/ipfilter-sve2.S
+@@ -370,10 +370,10 @@
+     cmp             x9, #16
+     bgt             .vl_gt_16_FILTER_LUMA_VPP_\v\()_\w\()x\h
+     qpel_start_\v
+-.loop_luma_vpp_sve2_\v\()_\w\()x\h:
++.Loop_luma_vpp_sve2_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_luma_vpp_w8_sve2_\v\()_\w\()x\h:
++.Loop_luma_vpp_w8_sve2_\v\()_\w\()x\h:
+     add             x6, x0, x9
+ .if \w == 8 || \w == 24
+     qpel_load_32b \v
+@@ -403,11 +403,11 @@
+     add             x9, x9, #16
+ .endif
+     cmp             x9, #\w
+-    blt             .loop_luma_vpp_w8_sve2_\v\()_\w\()x\h
++    blt             .Loop_luma_vpp_w8_sve2_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_luma_vpp_sve2_\v\()_\w\()x\h
++    cbnz            x5, .Loop_luma_vpp_sve2_\v\()_\w\()x\h
+     ret
+ .vl_gt_16_FILTER_LUMA_VPP_\v\()_\w\()x\h:
+     ptrue           p0.h, vl8
+@@ -456,7 +456,7 @@
+ 
+ // void interp_vert_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VPP_SVE2 w, h
+-function x265_interp_8tap_vert_pp_\w\()x\h\()_sve2
++function PFX(interp_8tap_vert_pp_\w\()x\h\()_sve2)
+     cmp             x4, #0
+     b.eq            0f
+     cmp             x4, #1
+@@ -501,7 +501,7 @@ LUMA_VPP_SVE2 64, 48
+ 
+ // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VPS_4xN_SVE2 h
+-function x265_interp_8tap_vert_ps_4x\h\()_sve2
++function PFX(interp_8tap_vert_ps_4x\h\()_sve2)
+     lsl             x3, x3, #1
+     lsl             x5, x4, #6
+     lsl             x4, x1, #2
+@@ -522,7 +522,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_sve2
+     ld1rd           {z22.d}, p0/z, [x12, #48]
+     ld1rd           {z23.d}, p0/z, [x12, #56]
+ 
+-.loop_vps_sve2_4x\h:
++.Loop_vps_sve2_4x\h:
+     mov             x6, x0
+ 
+     ld1b            {z0.s}, p0/z, [x6]
+@@ -557,7 +557,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_sve2
+ 
+     add             x0, x0, x1
+     sub             x4, x4, #1
+-    cbnz            x4, .loop_vps_sve2_4x\h
++    cbnz            x4, .Loop_vps_sve2_4x\h
+     ret
+ endfunc
+ .endm
+@@ -568,7 +568,7 @@ LUMA_VPS_4xN_SVE2 16
+ 
+ // void interp_vert_sp_c(const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VSP_4xN_SVE2 h
+-function x265_interp_8tap_vert_sp_4x\h\()_sve2
++function PFX(interp_8tap_vert_sp_4x\h\()_sve2)
+     lsl             x5, x4, #6
+     lsl             x1, x1, #1
+     lsl             x4, x1, #2
+@@ -593,7 +593,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_sve2
+     ld1rd           {z22.d}, p0/z, [x12, #48]
+     ld1rd           {z23.d}, p0/z, [x12, #56]
+ 
+-.loop_vsp_sve2_4x\h:
++.Loop_vsp_sve2_4x\h:
+     mov             x6, x0
+ 
+     ld1             {v0.8b}, [x6], x1
+@@ -630,7 +630,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_sve2
+ 
+     add             x0, x0, x1
+     sub             x4, x4, #1
+-    cbnz            x4, .loop_vsp_sve2_4x\h
++    cbnz            x4, .Loop_vsp_sve2_4x\h
+     ret
+ endfunc
+ .endm
+@@ -654,10 +654,10 @@ LUMA_VSP_4xN_SVE2 16
+     cmp             x14, #16
+     bgt             .vl_gt_16_FILTER_VPS_\v\()_\w\()x\h
+     qpel_start_\v
+-.loop_ps_sve2_\v\()_\w\()x\h:
++.Loop_ps_sve2_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_ps_w8_sve2_\v\()_\w\()x\h:
++.Loop_ps_w8_sve2_\v\()_\w\()x\h:
+     add             x6, x0, x9
+ .if \w == 8 || \w == 24
+     qpel_load_32b \v
+@@ -685,11 +685,11 @@ LUMA_VSP_4xN_SVE2 16
+     add             x9, x9, #16
+ .endif
+     cmp             x9, #\w
+-    blt             .loop_ps_w8_sve2_\v\()_\w\()x\h
++    blt             .Loop_ps_w8_sve2_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_ps_sve2_\v\()_\w\()x\h
++    cbnz            x5, .Loop_ps_sve2_\v\()_\w\()x\h
+     ret
+ .vl_gt_16_FILTER_VPS_\v\()_\w\()x\h:
+     ptrue           p0.h, vl8
+@@ -736,7 +736,7 @@ LUMA_VSP_4xN_SVE2 16
+ 
+ // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VPS_SVE2 w, h
+-function x265_interp_8tap_vert_ps_\w\()x\h\()_sve2
++function PFX(interp_8tap_vert_ps_\w\()x\h\()_sve2)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -796,10 +796,10 @@ LUMA_VPS_SVE2 64, 48
+     mov             x12, #\w
+     lsl             x12, x12, #1
+     qpel_start_\v\()_1
+-.loop_luma_vss_sve2_\v\()_\w\()x\h:
++.Loop_luma_vss_sve2_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_luma_vss_w8_sve2_\v\()_\w\()x\h:
++.Loop_luma_vss_w8_sve2_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_load_64b \v
+     qpel_filter_\v\()_32b_1
+@@ -820,17 +820,17 @@ LUMA_VPS_SVE2 64, 48
+ .endif
+ .endif
+     cmp             x9, x12
+-    blt             .loop_luma_vss_w8_sve2_\v\()_\w\()x\h
++    blt             .Loop_luma_vss_w8_sve2_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_luma_vss_sve2_\v\()_\w\()x\h
++    cbnz            x5, .Loop_luma_vss_sve2_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+ // void interp_vert_ss_c(const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VSS_SVE2 w, h
+-function x265_interp_8tap_vert_ss_\w\()x\h\()_sve2
++function PFX(interp_8tap_vert_ss_\w\()x\h\()_sve2)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -884,10 +884,10 @@ LUMA_VSS_SVE2 48, 64
+     mov             z31.h, #32
+     sub             x0, x0, x1
+     mov             x5, #\h
+-.loop_chroma_vpp_sve2_\v\()_\w\()x\h:
++.Loop_chroma_vpp_sve2_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_chroma_vpp_w8_sve2_\v\()_\w\()x\h:
++.Loop_chroma_vpp_w8_sve2_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_chroma_load_32b_sve2 \v
+     qpel_filter_chroma_sve2_\v\()_32b
+@@ -914,17 +914,17 @@ LUMA_VSS_SVE2 48, 64
+     str             d17, [x7], #8
+ .endif
+     cmp             x9, #\w
+-    blt             .loop_chroma_vpp_w8_sve2_\v\()_\w\()x\h
++    blt             .Loop_chroma_vpp_w8_sve2_\v\()_\w\()x\h
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_chroma_vpp_sve2_\v\()_\w\()x\h
++    cbnz            x5, .Loop_chroma_vpp_sve2_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+ // void interp_vert_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro CHROMA_VPP_SVE2 w, h
+-function x265_interp_4tap_vert_pp_\w\()x\h\()_sve2
++function PFX(interp_4tap_vert_pp_\w\()x\h\()_sve2)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -1008,10 +1008,10 @@ CHROMA_VPP_SVE2 48, 64
+     lsl             x3, x3, #1
+     sub             x0, x0, x1
+     mov             x5, #\h
+-.loop_vps_sve2_\v\()_\w\()x\h:
++.Loop_vps_sve2_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+-.loop_vps_w8_sve2_\v\()_\w\()x\h:
++.Loop_vps_w8_sve2_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_chroma_load_32b_sve2 \v
+     qpel_filter_chroma_sve2_\v\()_32b
+@@ -1036,18 +1036,18 @@ CHROMA_VPP_SVE2 48, 64
+     str             q17, [x7], #16
+ .endif
+     cmp             x9, #\w
+-    blt             .loop_vps_w8_sve2_\v\()_\w\()x\h
++    blt             .Loop_vps_w8_sve2_\v\()_\w\()x\h
+ 
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_vps_sve2_\v\()_\w\()x\h
++    cbnz            x5, .Loop_vps_sve2_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+ // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro CHROMA_VPS_SVE2 w, h
+-function x265_interp_4tap_vert_ps_\w\()x\h\()_sve2
++function PFX(interp_4tap_vert_ps_\w\()x\h\()_sve2)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -1170,7 +1170,7 @@ CHROMA_VPS_SVE2 48, 64
+     mov             x12, #\w
+     lsl             x12, x12, #1
+     qpel_start_chroma_sve2_\v\()_1
+-.loop_vss_sve2_\v\()_\w\()x\h:
++.Loop_vss_sve2_\v\()_\w\()x\h:
+     mov             x7, x2
+     mov             x9, #0
+ .if \w == 4
+@@ -1183,7 +1183,7 @@ CHROMA_VPS_SVE2 48, 64
+     add             x9, x9, #4
+ .endr
+ .else
+-.loop_vss_w8_sve2_\v\()_\w\()x\h:
++.Loop_vss_w8_sve2_\v\()_\w\()x\h:
+     add             x6, x0, x9
+     qpel_chroma_load_64b \v
+     qpel_filter_chroma_\v\()_32b_1
+@@ -1199,18 +1199,18 @@ CHROMA_VPS_SVE2 48, 64
+     add             x9, x9, #8
+ .endif
+     cmp             x9, x12
+-    blt             .loop_vss_w8_sve2_\v\()_\w\()x\h
++    blt             .Loop_vss_w8_sve2_\v\()_\w\()x\h
+ .endif
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_vss_sve2_\v\()_\w\()x\h
++    cbnz            x5, .Loop_vss_sve2_\v\()_\w\()x\h
+     ret
+ .endm
+ 
+ // void interp_vert_ss_c(const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro CHROMA_VSS_SVE2 w, h
+-function x265_interp_4tap_vert_ss_\w\()x\h\()_sve2
++function PFX(interp_4tap_vert_ss_\w\()x\h\()_sve2)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+diff --git a/source/common/aarch64/ipfilter.S b/source/common/aarch64/ipfilter.S
+index 80624862d..0d1a374eb 100644
+--- a/source/common/aarch64/ipfilter.S
++++ b/source/common/aarch64/ipfilter.S
+@@ -51,7 +51,7 @@
+ // ***** luma_vpp *****
+ // void interp_vert_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VPP_4xN h
+-function x265_interp_8tap_vert_pp_4x\h\()_neon
++function PFX(interp_8tap_vert_pp_4x\h\()_neon)
+     movrel          x10, g_luma_s16
+     sub             x0, x0, x1
+     sub             x0, x0, x1, lsl #1         // src -= 3 * srcStride
+@@ -85,7 +85,7 @@ function x265_interp_8tap_vert_pp_4x\h\()_neon
+     ushll           v3.8h, v3.8b, #0
+ 
+     mov             x9, #\h
+-.loop_4x\h:
++.Loop_4x\h:
+     ld1             {v4.s}[0], [x0], x1
+     ld1             {v4.s}[1], [x0], x1
+     ushll           v4.8h, v4.8b, #0
+@@ -124,7 +124,7 @@ function x265_interp_8tap_vert_pp_4x\h\()_neon
+     st1             {v16.s}[1], [x2], x3
+ 
+     sub             x9, x9, #2
+-    cbnz            x9, .loop_4x\h
++    cbnz            x9, .Loop_4x\h
+     ret
+ endfunc
+ .endm
+@@ -135,7 +135,7 @@ LUMA_VPP_4xN 16
+ 
+ // void interp_vert_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VPP w, h
+-function x265_interp_8tap_vert_pp_\w\()x\h\()_neon
++function PFX(interp_8tap_vert_pp_\w\()x\h\()_neon)
+     cmp             x4, #0
+     b.eq            0f
+     cmp             x4, #1
+@@ -181,7 +181,7 @@ LUMA_VPP 64, 48
+ // ***** luma_vps *****
+ // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VPS_4xN h
+-function x265_interp_8tap_vert_ps_4x\h\()_neon
++function PFX(interp_8tap_vert_ps_4x\h\()_neon)
+     lsl             x3, x3, #1
+     lsl             x5, x4, #6
+     lsl             x4, x1, #2
+@@ -202,7 +202,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_neon
+     ld1r            {v22.2d}, [x12], #8
+     ld1r            {v23.2d}, [x12], #8
+ 
+-.loop_vps_4x\h:
++.Loop_vps_4x\h:
+     mov             x6, x0
+ 
+     ld1             {v0.s}[0], [x6], x1
+@@ -252,7 +252,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_neon
+ 
+     add             x0, x0, x1
+     sub             x4, x4, #1
+-    cbnz            x4, .loop_vps_4x\h
++    cbnz            x4, .Loop_vps_4x\h
+     ret
+ endfunc
+ .endm
+@@ -263,7 +263,7 @@ LUMA_VPS_4xN 16
+ 
+ // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VPS w, h
+-function x265_interp_8tap_vert_ps_\w\()x\h\()_neon
++function PFX(interp_8tap_vert_ps_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -309,7 +309,7 @@ LUMA_VPS 64, 48
+ // ***** luma_vsp *****
+ // void interp_vert_sp_c(const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VSP_4xN h
+-function x265_interp_8tap_vert_sp_4x\h\()_neon
++function PFX(interp_8tap_vert_sp_4x\h\()_neon)
+     lsl             x5, x4, #6
+     lsl             x1, x1, #1
+     lsl             x4, x1, #2
+@@ -331,7 +331,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_neon
+     ld1r            {v21.2d}, [x12], #8
+     ld1r            {v22.2d}, [x12], #8
+     ld1r            {v23.2d}, [x12], #8
+-.loop_vsp_4x\h:
++.Loop_vsp_4x\h:
+     mov             x6, x0
+ 
+     ld1             {v0.8b}, [x6], x1
+@@ -368,7 +368,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_neon
+ 
+     add             x0, x0, x1
+     sub             x4, x4, #1
+-    cbnz            x4, .loop_vsp_4x\h
++    cbnz            x4, .Loop_vsp_4x\h
+     ret
+ endfunc
+ .endm
+@@ -379,7 +379,7 @@ LUMA_VSP_4xN 16
+ 
+ // void interp_vert_sp_c(const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VSP w, h
+-function x265_interp_8tap_vert_sp_\w\()x\h\()_neon
++function PFX(interp_8tap_vert_sp_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -425,7 +425,7 @@ LUMA_VSP 48, 64
+ // ***** luma_vss *****
+ // void interp_vert_ss_c(const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_VSS w, h
+-function x265_interp_8tap_vert_ss_\w\()x\h\()_neon
++function PFX(interp_8tap_vert_ss_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -474,7 +474,7 @@ LUMA_VSS 48, 64
+ // ***** luma_hpp *****
+ // void interp_horiz_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro LUMA_HPP w, h
+-function x265_interp_horiz_pp_\w\()x\h\()_neon
++function PFX(interp_horiz_pp_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -523,7 +523,7 @@ LUMA_HPP 64, 64
+ // ***** luma_hps *****
+ // void interp_horiz_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx, int isRowExt)
+ .macro LUMA_HPS w, h
+-function x265_interp_horiz_ps_\w\()x\h\()_neon
++function PFX(interp_horiz_ps_\w\()x\h\()_neon)
+     mov             w10, #\h
+     cmp             w5, #0
+     b.eq            6f
+@@ -580,7 +580,7 @@ LUMA_HPS 64, 64
+ // ***** chroma_vpp *****
+ // void interp_vert_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro CHROMA_VPP w, h
+-function x265_interp_4tap_vert_pp_\w\()x\h\()_neon
++function PFX(interp_4tap_vert_pp_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -660,7 +660,7 @@ CHROMA_VPP 48, 64
+ // ***** chroma_vps *****
+ // void interp_vert_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro CHROMA_VPS w, h
+-function x265_interp_4tap_vert_ps_\w\()x\h\()_neon
++function PFX(interp_4tap_vert_ps_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -740,7 +740,7 @@ CHROMA_VPS 48, 64
+ // ***** chroma_vsp *****
+ // void interp_vert_sp_c(const int16_t* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro CHROMA_VSP w, h
+-function x265_interp_4tap_vert_sp_\w\()x\h\()_neon
++function PFX(interp_4tap_vert_sp_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -814,7 +814,7 @@ CHROMA_VSP 48, 64
+ // ***** chroma_vss *****
+ // void interp_vert_ss_c(const int16_t* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx)
+ .macro CHROMA_VSS w, h
+-function x265_interp_4tap_vert_ss_\w\()x\h\()_neon
++function PFX(interp_4tap_vert_ss_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -888,7 +888,7 @@ CHROMA_VSS 48, 64
+ // ***** chroma_hpp *****
+ // void interp_horiz_pp_c(const pixel* src, intptr_t srcStride, pixel* dst, intptr_t dstStride, int coeffIdx)
+ .macro CHROMA_HPP w, h
+-function x265_interp_4tap_horiz_pp_\w\()x\h\()_neon
++function PFX(interp_4tap_horiz_pp_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+@@ -968,7 +968,7 @@ CHROMA_HPP 64, 64
+ // ***** chroma_hps *****
+ // void interp_horiz_ps_c(const pixel* src, intptr_t srcStride, int16_t* dst, intptr_t dstStride, int coeffIdx, int isRowExt)
+ .macro CHROMA_HPS w, h
+-function x265_interp_4tap_horiz_ps_\w\()x\h\()_neon
++function PFX(interp_4tap_horiz_ps_\w\()x\h\()_neon)
+     cmp             x4, #0
+     beq             0f
+     cmp             x4, #1
+diff --git a/source/common/aarch64/loopfilter-prim.cpp b/source/common/aarch64/loopfilter-prim.cpp
+index cb6ad4cd9..37679c0b6 100644
+--- a/source/common/aarch64/loopfilter-prim.cpp
++++ b/source/common/aarch64/loopfilter-prim.cpp
+@@ -1,3 +1,4 @@
++#include "common.h"
+ #include "loopfilter-prim.h"
+ 
+ #define PIXEL_MIN 0
+@@ -11,12 +12,6 @@ namespace
+ {
+ 
+ 
+-/* get the sign of input variable (TODO: this is a dup, make common) */
+-static inline int8_t signOf(int x)
+-{
+-    return (x >> 31) | ((int)((((uint32_t) - x)) >> 31));
+-}
+-
+ static inline int8x8_t sign_diff_neon(const uint8x8_t in0, const uint8x8_t in1)
+ {
+     int16x8_t in = vsubl_u8(in0, in1);
+@@ -33,7 +28,7 @@ static void calSign_neon(int8_t *dst, const pixel *src1, const pixel *src2, cons
+ 
+     for (; x < endX; x++)
+     {
+-        dst[x] = signOf(src1[x] - src2[x]);
++        dst[x] = x265_signOf(src1[x] - src2[x]);
+     }
+ }
+ 
+@@ -108,7 +103,7 @@ static void processSaoCUE1_neon(pixel *rec, int8_t *upBuff1, int8_t *offsetEo, i
+     }
+     for (; x < width; x++)
+     {
+-        signDown = signOf(rec[x] - rec[x + stride]);
++        signDown = x265_signOf(rec[x] - rec[x + stride]);
+         edgeType = signDown + upBuff1[x] + 2;
+         upBuff1[x] = -signDown;
+         rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);
+@@ -144,7 +139,7 @@ static void processSaoCUE1_2Rows_neon(pixel *rec, int8_t *upBuff1, int8_t *offse
+         }
+         for (; x < width; x++)
+         {
+-            signDown = signOf(rec[x] - rec[x + stride]);
++            signDown = x265_signOf(rec[x] - rec[x + stride]);
+             edgeType = signDown + upBuff1[x] + 2;
+             upBuff1[x] = -signDown;
+             rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);
+@@ -161,7 +156,7 @@ static void processSaoCUE2_neon(pixel *rec, int8_t *bufft, int8_t *buff1, int8_t
+     {
+         for (x = 0; x < width; x++)
+         {
+-            int8_t signDown = signOf(rec[x] - rec[x + stride + 1]);
++            int8_t signDown = x265_signOf(rec[x] - rec[x + stride + 1]);
+             int edgeType = signDown + buff1[x] + 2;
+             bufft[x + 1] = -signDown;
+             rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);;
+@@ -186,7 +181,7 @@ static void processSaoCUE2_neon(pixel *rec, int8_t *bufft, int8_t *buff1, int8_t
+         }
+         for (; x < width; x++)
+         {
+-            int8_t signDown = signOf(rec[x] - rec[x + stride + 1]);
++            int8_t signDown = x265_signOf(rec[x] - rec[x + stride + 1]);
+             int edgeType = signDown + buff1[x] + 2;
+             bufft[x + 1] = -signDown;
+             rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);;
+@@ -219,7 +214,7 @@ static void processSaoCUE3_neon(pixel *rec, int8_t *upBuff1, int8_t *offsetEo, i
+     }
+     for (; x < endX; x++)
+     {
+-        signDown = signOf(rec[x] - rec[x + stride]);
++        signDown = x265_signOf(rec[x] - rec[x + stride]);
+         edgeType = signDown + upBuff1[x] + 2;
+         upBuff1[x - 1] = -signDown;
+         rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);
+diff --git a/source/common/aarch64/mc-a-sve2.S b/source/common/aarch64/mc-a-sve2.S
+index 704bdaed0..e4540ce9b 100644
+--- a/source/common/aarch64/mc-a-sve2.S
++++ b/source/common/aarch64/mc-a-sve2.S
+@@ -219,7 +219,7 @@ function PFX(pixel_avg_pp_48x64_sve2)
+     mov             x11, #0
+     whilelt         p0.b, x11, x10
+     mov             w12, #8
+-.loop_gt_32_pixel_avg_pp_48x64:
++.Loop_gt_32_pixel_avg_pp_48x64:
+     sub             w12, w12, #1
+ .rept 8
+     ld1b            {z0.b}, p0/z, [x2]
+@@ -230,7 +230,7 @@ function PFX(pixel_avg_pp_48x64_sve2)
+     st1b            {z0.b}, p0, [x0]
+     add             x0, x0, x1
+ .endr
+-    cbnz            w12, .loop_gt_32_pixel_avg_pp_48x64
++    cbnz            w12, .Loop_gt_32_pixel_avg_pp_48x64
+     ret
+ endfunc
+ 
+@@ -339,7 +339,7 @@ function PFX(addAvg_6x\h\()_sve2)
+     mov             w12, #\h / 2
+     ptrue           p0.b, vl16
+     ptrue           p2.h, vl6
+-.loop_sve2_addavg_6x\h\():
++.Loop_sve2_addavg_6x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x1]
+@@ -359,7 +359,7 @@ function PFX(addAvg_6x\h\()_sve2)
+     add             x2, x2, x5
+     st1b            {z2.h}, p2, [x2]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_sve2_addavg_6x\h
++    cbnz            w12, .Loop_sve2_addavg_6x\h
+     ret
+ endfunc
+ .endm
+@@ -398,7 +398,7 @@ endfunc
+ function PFX(addAvg_8x\h\()_sve2)
+     mov             w12, #\h / 2
+     ptrue           p0.b, vl16
+-.loop_sve2_addavg_8x\h\():
++.Loop_sve2_addavg_8x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x1]
+@@ -418,7 +418,7 @@ function PFX(addAvg_8x\h\()_sve2)
+     add             x2, x2, x5
+     st1b            {z2.h}, p0, [x2]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_sve2_addavg_8x\h
++    cbnz            w12, .Loop_sve2_addavg_8x\h
+     ret
+ endfunc
+ .endm
+@@ -440,7 +440,7 @@ function PFX(addAvg_12x\h\()_sve2)
+     bgt             .vl_gt_16_addAvg_12x\h
+     ptrue           p0.b, vl16
+     ptrue           p1.b, vl8
+-.loop_sve2_addavg_12x\h\():
++.Loop_sve2_addavg_12x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x1]
+@@ -457,13 +457,13 @@ function PFX(addAvg_12x\h\()_sve2)
+     st1b            {z0.h}, p0, [x2]
+     st1b            {z2.h}, p1, [x2, #1, mul vl]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_sve2_addavg_12x\h
++    cbnz            w12, .Loop_sve2_addavg_12x\h
+     ret
+ .vl_gt_16_addAvg_12x\h\():
+     mov             x10, #24
+     mov             x11, #0
+     whilelt         p0.b, x11, x10
+-.loop_sve2_gt_16_addavg_12x\h\():
++.Loop_sve2_gt_16_addavg_12x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x1]
+@@ -476,7 +476,7 @@ function PFX(addAvg_12x\h\()_sve2)
+     add             z2.b, z2.b, #0x80
+     st1b            {z0.h}, p0, [x2]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_sve2_gt_16_addavg_12x\h
++    cbnz            w12, .Loop_sve2_gt_16_addavg_12x\h
+     ret
+ endfunc
+ .endm
+@@ -491,7 +491,7 @@ function PFX(addAvg_16x\h\()_sve2)
+     cmp             x9, #16
+     bgt             .vl_gt_16_addAvg_16x\h
+     ptrue           p0.b, vl16
+-.loop_eq_16_sve2_addavg_16x\h\():
++.Loop_eq_16_sve2_addavg_16x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x1]
+@@ -508,13 +508,13 @@ function PFX(addAvg_16x\h\()_sve2)
+     st1b            {z0.h}, p0, [x2]
+     st1b            {z2.h}, p0, [x2, #1, mul vl]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_eq_16_sve2_addavg_16x\h
++    cbnz            w12, .Loop_eq_16_sve2_addavg_16x\h
+     ret
+ .vl_gt_16_addAvg_16x\h\():
+     cmp             x9, #32
+     bgt             .vl_gt_32_addAvg_16x\h
+     ptrue           p0.b, vl32
+-.loop_gt_16_sve2_addavg_16x\h\():
++.Loop_gt_16_sve2_addavg_16x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x1]
+@@ -525,13 +525,13 @@ function PFX(addAvg_16x\h\()_sve2)
+     add             z0.b, z0.b, #0x80
+     st1b            {z0.h}, p1, [x2]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_16_sve2_addavg_16x\h
++    cbnz            w12, .Loop_gt_16_sve2_addavg_16x\h
+     ret
+ .vl_gt_32_addAvg_16x\h\():
+     mov             x10, #48
+     mov             x11, #0
+     whilelt         p0.b, x11, x10
+-.loop_gt_32_sve2_addavg_16x\h\():
++.Loop_gt_32_sve2_addavg_16x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     add             x0, x0, x3, lsl #1
+@@ -541,7 +541,7 @@ function PFX(addAvg_16x\h\()_sve2)
+     add             z0.b, z0.b, #0x80
+     st1b            {z0.h}, p0, [x2]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_32_sve2_addavg_16x\h
++    cbnz            w12, .Loop_gt_32_sve2_addavg_16x\h
+     ret
+ endfunc
+ .endm
+@@ -561,7 +561,7 @@ function PFX(addAvg_24x\h\()_sve2)
+     cmp             x9, #16
+     bgt             .vl_gt_16_addAvg_24x\h
+     addAvg_start
+-.loop_eq_16_sve2_addavg_24x\h\():
++.Loop_eq_16_sve2_addavg_24x\h\():
+     sub             w12, w12, #1
+     ld1             {v0.16b-v2.16b}, [x0], x3
+     ld1             {v3.16b-v5.16b}, [x1], x4
+@@ -572,14 +572,14 @@ function PFX(addAvg_24x\h\()_sve2)
+     sqxtun          v1.8b, v1.8h
+     sqxtun          v2.8b, v2.8h
+     st1             {v0.8b-v2.8b}, [x2], x5
+-    cbnz            w12, .loop_eq_16_sve2_addavg_24x\h
++    cbnz            w12, .Loop_eq_16_sve2_addavg_24x\h
+     ret
+ .vl_gt_16_addAvg_24x\h\():
+     cmp             x9, #48
+     bgt             .vl_gt_48_addAvg_24x\h
+     ptrue           p0.b, vl32
+     ptrue           p1.b, vl16
+-.loop_gt_16_sve2_addavg_24x\h\():
++.Loop_gt_16_sve2_addavg_24x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p1/z, [x0, #1, mul vl]
+@@ -596,13 +596,13 @@ function PFX(addAvg_24x\h\()_sve2)
+     st1b            {z0.h}, p0, [x2]
+     st1b            {z1.h}, p1, [x2, #1, mul vl]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_16_sve2_addavg_24x\h
++    cbnz            w12, .Loop_gt_16_sve2_addavg_24x\h
+     ret
+ .vl_gt_48_addAvg_24x\h\():
+     mov             x10, #48
+     mov             x11, #0
+     whilelt         p0.b, x11, x10
+-.loop_gt_48_sve2_addavg_24x\h\():
++.Loop_gt_48_sve2_addavg_24x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z2.b}, p0/z, [x1]
+@@ -613,7 +613,7 @@ function PFX(addAvg_24x\h\()_sve2)
+     add             z0.b, z0.b, #0x80
+     st1b            {z0.h}, p0, [x2]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_48_sve2_addavg_24x\h
++    cbnz            w12, .Loop_gt_48_sve2_addavg_24x\h
+     ret
+ endfunc
+ .endm
+@@ -628,7 +628,7 @@ function PFX(addAvg_32x\h\()_sve2)
+     cmp             x9, #16
+     bgt             .vl_gt_16_addAvg_32x\h
+     ptrue           p0.b, vl16
+-.loop_eq_16_sve2_addavg_32x\h\():
++.Loop_eq_16_sve2_addavg_32x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x0, #1, mul vl]
+@@ -657,13 +657,13 @@ function PFX(addAvg_32x\h\()_sve2)
+     st1b            {z2.h}, p0, [x2, #2, mul vl]
+     st1b            {z3.h}, p0, [x2, #3, mul vl]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_eq_16_sve2_addavg_32x\h
++    cbnz            w12, .Loop_eq_16_sve2_addavg_32x\h
+     ret
+ .vl_gt_16_addAvg_32x\h\():
+     cmp             x9, #48
+     bgt             .vl_gt_48_addAvg_32x\h
+     ptrue           p0.b, vl32
+-.loop_gt_eq_32_sve2_addavg_32x\h\():
++.Loop_gt_eq_32_sve2_addavg_32x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x0, #1, mul vl]
+@@ -680,11 +680,11 @@ function PFX(addAvg_32x\h\()_sve2)
+     st1b            {z0.h}, p0, [x2]
+     st1b            {z1.h}, p0, [x2, #1, mul vl]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_eq_32_sve2_addavg_32x\h
++    cbnz            w12, .Loop_gt_eq_32_sve2_addavg_32x\h
+     ret
+ .vl_gt_48_addAvg_32x\h\():
+     ptrue           p0.b, vl64
+-.loop_eq_64_sve2_addavg_32x\h\():
++.Loop_eq_64_sve2_addavg_32x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x1]
+@@ -695,7 +695,7 @@ function PFX(addAvg_32x\h\()_sve2)
+     add             z0.b, z0.b, #0x80
+     st1b            {z0.h}, p0, [x2]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_eq_64_sve2_addavg_32x\h
++    cbnz            w12, .Loop_eq_64_sve2_addavg_32x\h
+     ret
+ endfunc
+ .endm
+@@ -715,7 +715,7 @@ function PFX(addAvg_48x64_sve2)
+     addAvg_start
+     sub             x3, x3, #64
+     sub             x4, x4, #64
+-.loop_eq_16_sve2_addavg_48x64:
++.Loop_eq_16_sve2_addavg_48x64:
+     sub             w12, w12, #1
+     ld1             {v0.8h-v3.8h}, [x0], #64
+     ld1             {v4.8h-v7.8h}, [x1], #64
+@@ -734,13 +734,13 @@ function PFX(addAvg_48x64_sve2)
+     sqxtun          v2.8b, v20.8h
+     sqxtun2         v2.16b, v21.8h
+     st1             {v0.16b-v2.16b}, [x2], x5
+-    cbnz            w12, .loop_eq_16_sve2_addavg_48x64
++    cbnz            w12, .Loop_eq_16_sve2_addavg_48x64
+     ret
+ .vl_gt_16_addAvg_48x64:
+     cmp             x9, #48
+     bgt             .vl_gt_48_addAvg_48x64
+     ptrue           p0.b, vl32
+-.loop_gt_eq_32_sve2_addavg_48x64:
++.Loop_gt_eq_32_sve2_addavg_48x64:
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x0, #1, mul vl]
+@@ -763,14 +763,14 @@ function PFX(addAvg_48x64_sve2)
+     st1b            {z1.h}, p0, [x2, #1, mul vl]
+     st1b            {z2.h}, p0, [x2, #2, mul vl]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_eq_32_sve2_addavg_48x64
++    cbnz            w12, .Loop_gt_eq_32_sve2_addavg_48x64
+     ret
+ .vl_gt_48_addAvg_48x64:
+     cmp             x9, #112
+     bgt             .vl_gt_112_addAvg_48x64
+     ptrue           p0.b, vl64
+     ptrue           p1.b, vl32
+-.loop_gt_48_sve2_addavg_48x64:
++.Loop_gt_48_sve2_addavg_48x64:
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p1/z, [x0, #1, mul vl]
+@@ -787,13 +787,13 @@ function PFX(addAvg_48x64_sve2)
+     st1b            {z0.h}, p0, [x2]
+     st1b            {z1.h}, p1, [x2, #1, mul vl]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_48_sve2_addavg_48x64
++    cbnz            w12, .Loop_gt_48_sve2_addavg_48x64
+     ret
+ .vl_gt_112_addAvg_48x64:
+     mov             x10, #96
+     mov             x11, #0
+     whilelt         p0.b, x11, x10
+-.loop_gt_112_sve2_addavg_48x64:
++.Loop_gt_112_sve2_addavg_48x64:
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z4.b}, p0/z, [x1]
+@@ -804,7 +804,7 @@ function PFX(addAvg_48x64_sve2)
+     add             z0.b, z0.b, #0x80
+     st1b            {z0.h}, p0, [x2]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_112_sve2_addavg_48x64
++    cbnz            w12, .Loop_gt_112_sve2_addavg_48x64
+     ret
+ endfunc
+ 
+@@ -817,7 +817,7 @@ function PFX(addAvg_64x\h\()_sve2)
+     addAvg_start
+     sub             x3, x3, #64
+     sub             x4, x4, #64
+-.loop_eq_16_sve2_addavg_64x\h\():
++.Loop_eq_16_sve2_addavg_64x\h\():
+     sub             w12, w12, #1
+     ld1             {v0.8h-v3.8h}, [x0], #64
+     ld1             {v4.8h-v7.8h}, [x1], #64
+@@ -840,13 +840,13 @@ function PFX(addAvg_64x\h\()_sve2)
+     sqxtun          v3.8b, v22.8h
+     sqxtun2         v3.16b, v23.8h
+     st1             {v0.16b-v3.16b}, [x2], x5
+-    cbnz            w12, .loop_eq_16_sve2_addavg_64x\h
++    cbnz            w12, .Loop_eq_16_sve2_addavg_64x\h
+     ret
+ .vl_gt_16_addAvg_64x\h\():
+     cmp             x9, #48
+     bgt             .vl_gt_48_addAvg_64x\h
+     ptrue           p0.b, vl32
+-.loop_gt_eq_32_sve2_addavg_64x\h\():
++.Loop_gt_eq_32_sve2_addavg_64x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x0, #1, mul vl]
+@@ -875,13 +875,13 @@ function PFX(addAvg_64x\h\()_sve2)
+     st1b            {z2.h}, p0, [x2, #2, mul vl]
+     st1b            {z3.h}, p0, [x2, #3, mul vl]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_eq_32_sve2_addavg_64x\h
++    cbnz            w12, .Loop_gt_eq_32_sve2_addavg_64x\h
+     ret
+ .vl_gt_48_addAvg_64x\h\():
+     cmp             x9, #112
+     bgt             .vl_gt_112_addAvg_64x\h
+     ptrue           p0.b, vl64
+-.loop_gt_eq_48_sve2_addavg_64x\h\():
++.Loop_gt_eq_48_sve2_addavg_64x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z1.b}, p0/z, [x0, #1, mul vl]
+@@ -898,11 +898,11 @@ function PFX(addAvg_64x\h\()_sve2)
+     st1b            {z0.h}, p0, [x2]
+     st1b            {z1.h}, p0, [x2, #1, mul vl]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_eq_48_sve2_addavg_64x\h
++    cbnz            w12, .Loop_gt_eq_48_sve2_addavg_64x\h
+     ret
+ .vl_gt_112_addAvg_64x\h\():
+     ptrue           p0.b, vl128
+-.loop_gt_eq_128_sve2_addavg_64x\h\():
++.Loop_gt_eq_128_sve2_addavg_64x\h\():
+     sub             w12, w12, #1
+     ld1b            {z0.b}, p0/z, [x0]
+     ld1b            {z4.b}, p0/z, [x1]
+@@ -913,7 +913,7 @@ function PFX(addAvg_64x\h\()_sve2)
+     add             z0.b, z0.b, #0x80
+     st1b            {z0.h}, p0, [x2]
+     add             x2, x2, x5
+-    cbnz            w12, .loop_gt_eq_128_sve2_addavg_64x\h
++    cbnz            w12, .Loop_gt_eq_128_sve2_addavg_64x\h
+     ret
+ endfunc
+ .endm
+diff --git a/source/common/aarch64/mc-a.S b/source/common/aarch64/mc-a.S
+index d122b8bb3..8c2878b3e 100644
+--- a/source/common/aarch64/mc-a.S
++++ b/source/common/aarch64/mc-a.S
+@@ -283,7 +283,7 @@ function PFX(addAvg_6x\h\()_neon)
+     addAvg_start
+     mov             w12, #\h / 2
+     sub             x5, x5, #4
+-.loop_addavg_6x\h:
++.Loop_addavg_6x\h:
+     sub             w12, w12, #1
+     ld1             {v0.16b}, [x0], x3
+     ld1             {v1.16b}, [x1], x4
+@@ -305,7 +305,7 @@ function PFX(addAvg_6x\h\()_neon)
+     st1             {v0.h}[2], [x2], x5
+     str             s1, [x2], #4
+     st1             {v1.h}[2], [x2], x5
+-    cbnz            w12, .loop_addavg_6x\h
++    cbnz            w12, .Loop_addavg_6x\h
+     ret
+ endfunc
+ .endm
+@@ -344,7 +344,7 @@ endfunc
+ function PFX(addAvg_8x\h\()_neon)
+     addAvg_start
+     mov             w12, #\h / 2
+-.loop_addavg_8x\h:
++.Loop_addavg_8x\h:
+     sub             w12, w12, #1
+     ld1             {v0.16b}, [x0], x3
+     ld1             {v1.16b}, [x1], x4
+@@ -364,7 +364,7 @@ function PFX(addAvg_8x\h\()_neon)
+     sqxtun          v1.8b, v1.8h
+     st1             {v0.8b}, [x2], x5
+     st1             {v1.8b}, [x2], x5
+-    cbnz            w12, .loop_addavg_8x\h
++    cbnz            w12, .Loop_addavg_8x\h
+     ret
+ endfunc
+ .endm
+@@ -385,7 +385,7 @@ function PFX(addAvg_12x\h\()_neon)
+     sub             x4, x4, #16
+     sub             x5, x5, #8
+     mov             w12, #\h
+-.loop_addAvg_12X\h\():
++.Loop_addAvg_12X\h\():
+     sub             w12, w12, #1
+     ld1             {v0.16b}, [x0], #16
+     ld1             {v1.16b}, [x1], #16
+@@ -403,7 +403,7 @@ function PFX(addAvg_12x\h\()_neon)
+     sqxtun          v1.8b, v1.8h
+     st1             {v0.8b}, [x2], #8
+     st1             {v1.s}[0], [x2], x5
+-    cbnz            w12, .loop_addAvg_12X\h
++    cbnz            w12, .Loop_addAvg_12X\h
+     ret
+ endfunc
+ .endm
+@@ -415,7 +415,7 @@ addAvg_12xN 32
+ function PFX(addAvg_16x\h\()_neon)
+     addAvg_start
+     mov             w12, #\h
+-.loop_addavg_16x\h:
++.Loop_addavg_16x\h:
+     sub             w12, w12, #1
+     ld1             {v0.8h-v1.8h}, [x0], x3
+     ld1             {v2.8h-v3.8h}, [x1], x4
+@@ -424,7 +424,7 @@ function PFX(addAvg_16x\h\()_neon)
+     sqxtun          v0.8b, v0.8h
+     sqxtun2         v0.16b, v1.8h
+     st1             {v0.16b}, [x2], x5
+-    cbnz            w12, .loop_addavg_16x\h
++    cbnz            w12, .Loop_addavg_16x\h
+     ret
+ endfunc
+ .endm
+@@ -441,7 +441,7 @@ addAvg_16xN 64
+ function PFX(addAvg_24x\h\()_neon)
+     addAvg_start
+     mov             w12, #\h
+-.loop_addavg_24x\h\():
++.Loop_addavg_24x\h\():
+     sub             w12, w12, #1
+     ld1             {v0.16b-v2.16b}, [x0], x3
+     ld1             {v3.16b-v5.16b}, [x1], x4
+@@ -452,7 +452,7 @@ function PFX(addAvg_24x\h\()_neon)
+     sqxtun          v1.8b, v1.8h
+     sqxtun          v2.8b, v2.8h
+     st1             {v0.8b-v2.8b}, [x2], x5
+-    cbnz            w12, .loop_addavg_24x\h
++    cbnz            w12, .Loop_addavg_24x\h
+     ret
+ endfunc
+ .endm
+@@ -464,7 +464,7 @@ addAvg_24xN 64
+ function PFX(addAvg_32x\h\()_neon)
+     addAvg_start
+     mov             w12, #\h
+-.loop_addavg_32x\h\():
++.Loop_addavg_32x\h\():
+     sub             w12, w12, #1
+     ld1             {v0.8h-v3.8h}, [x0], x3
+     ld1             {v4.8h-v7.8h}, [x1], x4
+@@ -477,7 +477,7 @@ function PFX(addAvg_32x\h\()_neon)
+     sqxtun          v2.8b, v2.8h
+     sqxtun          v3.8b, v3.8h
+     st1             {v0.8b-v3.8b}, [x2], x5
+-    cbnz            w12, .loop_addavg_32x\h
++    cbnz            w12, .Loop_addavg_32x\h
+     ret
+ endfunc
+ .endm
+@@ -494,7 +494,7 @@ function PFX(addAvg_48x64_neon)
+     sub             x3, x3, #64
+     sub             x4, x4, #64
+     mov             w12, #64
+-.loop_addavg_48x64:
++.Loop_addavg_48x64:
+     sub             w12, w12, #1
+     ld1             {v0.8h-v3.8h}, [x0], #64
+     ld1             {v4.8h-v7.8h}, [x1], #64
+@@ -513,7 +513,7 @@ function PFX(addAvg_48x64_neon)
+     sqxtun          v2.8b, v20.8h
+     sqxtun2         v2.16b, v21.8h
+     st1             {v0.16b-v2.16b}, [x2], x5
+-    cbnz            w12, .loop_addavg_48x64
++    cbnz            w12, .Loop_addavg_48x64
+     ret
+ endfunc
+ 
+@@ -523,7 +523,7 @@ function PFX(addAvg_64x\h\()_neon)
+     mov             w12, #\h
+     sub             x3, x3, #64
+     sub             x4, x4, #64
+-.loop_addavg_64x\h\():
++.Loop_addavg_64x\h\():
+     sub             w12, w12, #1
+     ld1             {v0.8h-v3.8h}, [x0], #64
+     ld1             {v4.8h-v7.8h}, [x1], #64
+@@ -546,7 +546,7 @@ function PFX(addAvg_64x\h\()_neon)
+     sqxtun          v3.8b, v22.8h
+     sqxtun2         v3.16b, v23.8h
+     st1             {v0.16b-v3.16b}, [x2], x5
+-    cbnz            w12, .loop_addavg_64x\h
++    cbnz            w12, .Loop_addavg_64x\h
+     ret
+ endfunc
+ .endm
+diff --git a/source/common/aarch64/p2s-sve.S b/source/common/aarch64/p2s-sve.S
+index dc32df2e6..85bb14b3d 100644
+--- a/source/common/aarch64/p2s-sve.S
++++ b/source/common/aarch64/p2s-sve.S
+@@ -204,7 +204,7 @@ function PFX(filterPixelToShort_32x\h\()_sve)
+ #else
+     p2s_start
+     mov             x9, #\h
+-.loop_filter_sve_P2S_32x\h:
++.Loop_filter_sve_P2S_32x\h:
+     sub             x9, x9, #1
+     ld1             {v0.16b-v1.16b}, [x0], x1
+     ushll           v22.8h, v0.8b,  #P2S_SHIFT
+@@ -216,7 +216,7 @@ function PFX(filterPixelToShort_32x\h\()_sve)
+     add             v24.8h, v24.8h, v31.8h
+     add             v25.8h, v25.8h, v31.8h
+     st1             {v22.16b-v25.16b}, [x2], x3
+-    cbnz            x9, .loop_filter_sve_P2S_32x\h
++    cbnz            x9, .Loop_filter_sve_P2S_32x\h
+     ret
+ #endif
+ endfunc
+@@ -331,7 +331,7 @@ function PFX(filterPixelToShort_64x\h\()_sve)
+     p2s_start
+     sub             x3, x3, #64
+     mov             x9, #\h
+-.loop_filter_sve_P2S_64x\h:
++.Loop_filter_sve_P2S_64x\h:
+     sub             x9, x9, #1
+     ld1             {v0.16b-v3.16b}, [x0], x1
+     ushll           v16.8h, v0.8b,  #P2S_SHIFT
+@@ -352,7 +352,7 @@ function PFX(filterPixelToShort_64x\h\()_sve)
+     add             v23.8h, v23.8h, v31.8h
+     st1             {v16.16b-v19.16b}, [x2], #64
+     st1             {v20.16b-v23.16b}, [x2], x3
+-    cbnz            x9, .loop_filter_sve_P2S_64x\h
++    cbnz            x9, .Loop_filter_sve_P2S_64x\h
+     ret
+ #endif
+ endfunc
+@@ -422,7 +422,7 @@ function PFX(filterPixelToShort_48x64_sve)
+     p2s_start
+     sub             x3, x3, #64
+     mov             x9, #64
+-.loop_filterP2S_sve_48x64:
++.Loop_filterP2S_sve_48x64:
+     sub            x9, x9, #1
+     ld1             {v0.16b-v2.16b}, [x0], x1
+     ushll           v16.8h, v0.8b,  #P2S_SHIFT
+@@ -439,7 +439,7 @@ function PFX(filterPixelToShort_48x64_sve)
+     add             v21.8h, v21.8h, v31.8h
+     st1             {v16.16b-v19.16b}, [x2], #64
+     st1             {v20.16b-v21.16b}, [x2], x3
+-    cbnz            x9, .loop_filterP2S_sve_48x64
++    cbnz            x9, .Loop_filterP2S_sve_48x64
+     ret
+ #endif
+ endfunc
+diff --git a/source/common/aarch64/p2s.S b/source/common/aarch64/p2s.S
+index 58301c9bf..b15835b34 100644
+--- a/source/common/aarch64/p2s.S
++++ b/source/common/aarch64/p2s.S
+@@ -262,7 +262,7 @@ p2s_24xN 64
+ function PFX(filterPixelToShort_32x\h\()_neon)
+     p2s_start
+     mov             x9, #\h
+-.loop_filterP2S_32x\h:
++.Loop_filterP2S_32x\h:
+     sub             x9, x9, #1
+ #if HIGH_BIT_DEPTH
+     ld1             {v0.16b-v3.16b}, [x0], x1
+@@ -282,7 +282,7 @@ function PFX(filterPixelToShort_32x\h\()_neon)
+     add             v24.8h, v24.8h, v31.8h
+     add             v25.8h, v25.8h, v31.8h
+     st1             {v22.16b-v25.16b}, [x2], x3
+-    cbnz            x9, .loop_filterP2S_32x\h
++    cbnz            x9, .Loop_filterP2S_32x\h
+     ret
+ endfunc
+ .endm
+@@ -302,7 +302,7 @@ function PFX(filterPixelToShort_64x\h\()_neon)
+ #endif
+     sub             x3, x3, #64
+     mov             x9, #\h
+-.loop_filterP2S_64x\h:
++.Loop_filterP2S_64x\h:
+     sub             x9, x9, #1
+ #if HIGH_BIT_DEPTH
+     ld1             {v0.16b-v3.16b}, [x0], #64
+@@ -336,7 +336,7 @@ function PFX(filterPixelToShort_64x\h\()_neon)
+     add             v23.8h, v23.8h, v31.8h
+     st1             {v16.16b-v19.16b}, [x2], #64
+     st1             {v20.16b-v23.16b}, [x2], x3
+-    cbnz            x9, .loop_filterP2S_64x\h
++    cbnz            x9, .Loop_filterP2S_64x\h
+     ret
+ endfunc
+ .endm
+@@ -353,7 +353,7 @@ function PFX(filterPixelToShort_48x64_neon)
+ #endif
+     sub             x3, x3, #64
+     mov             x9, #64
+-.loop_filterP2S_48x64:
++.Loop_filterP2S_48x64:
+     sub            x9, x9, #1
+ #if HIGH_BIT_DEPTH
+     ld1             {v0.16b-v3.16b}, [x0], #64
+@@ -381,6 +381,6 @@ function PFX(filterPixelToShort_48x64_neon)
+     add             v21.8h, v21.8h, v31.8h
+     st1             {v16.16b-v19.16b}, [x2], #64
+     st1             {v20.16b-v21.16b}, [x2], x3
+-    cbnz            x9, .loop_filterP2S_48x64
++    cbnz            x9, .Loop_filterP2S_48x64
+     ret
+ endfunc
+diff --git a/source/common/aarch64/pixel-prim.cpp b/source/common/aarch64/pixel-prim.cpp
+index 7164cd99f..f073251d3 100644
+--- a/source/common/aarch64/pixel-prim.cpp
++++ b/source/common/aarch64/pixel-prim.cpp
+@@ -1069,10 +1069,9 @@ void sad_x4_neon(const pixel *pix1, const pixel *pix2, const pixel *pix3, const
+         {
+             /* This is equivalent to adding across each of the sum vectors and then adding
+              * to result. */
+-            uint16x8_t a = vpaddq_s16(vsum16_0, vsum16_1);
+-            uint16x8_t b = vpaddq_s16(vsum16_2, vsum16_3);
+-            uint16x8_t c = vpaddq_s16(a, b);
+-            result = vpadalq_s16(result, c);
++            uint32x4_t sum01 = vpaddlq_u16(vpaddq_u16(vsum16_0, vsum16_1));
++            uint32x4_t sum23 = vpaddlq_u16(vpaddq_u16(vsum16_2, vsum16_3));
++            result = vaddq_u32(result, vpaddq_u32(sum01, sum23));
+         }
+ 
+ #else
+diff --git a/source/common/aarch64/pixel-util-sve.S b/source/common/aarch64/pixel-util-sve.S
+index 715fcc1cb..c1d6b4129 100644
+--- a/source/common/aarch64/pixel-util-sve.S
++++ b/source/common/aarch64/pixel-util-sve.S
+@@ -333,7 +333,7 @@ function PFX(quant_sve)
+     eor             w10, w10, w10
+     eor             z17.d, z17.d, z17.d
+ 
+-.loop_quant_sve:
++.Loop_quant_sve:
+     ld1             {v18.4h}, [x0], #8
+     ld1             {v7.4s}, [x1], #16
+     sxtl            v6.4s, v18.4h
+@@ -364,7 +364,7 @@ function PFX(quant_sve)
+     st1             {v5.4h}, [x3], #8
+ 
+     subs            w6, w6, #1
+-    b.ne             .loop_quant_sve
++    b.ne             .Loop_quant_sve
+ 
+     addv            s4, v4.4s
+     mov             w9, v4.s[0]
+diff --git a/source/common/aarch64/pixel-util-sve2.S b/source/common/aarch64/pixel-util-sve2.S
+index dbd138f62..2af5d63c1 100644
+--- a/source/common/aarch64/pixel-util-sve2.S
++++ b/source/common/aarch64/pixel-util-sve2.S
+@@ -64,11 +64,11 @@ function PFX(pixel_var_16x16_sve2)
+     bgt             .vl_gt_16_pixel_var_16x16
+     pixel_var_start
+     mov             w12, #16
+-.loop_var_16_sve2:
++.Loop_var_16_sve2:
+     sub             w12, w12, #1
+     ld1             {v4.16b}, [x0], x1
+     pixel_var_1 v4
+-    cbnz            w12, .loop_var_16_sve2
++    cbnz            w12, .Loop_var_16_sve2
+     pixel_var_end
+     ret
+ .vl_gt_16_pixel_var_16x16:
+@@ -95,12 +95,12 @@ function PFX(pixel_var_32x32_sve2)
+     bgt             .vl_gt_16_pixel_var_32x32
+     pixel_var_start
+     mov             w12, #32
+-.loop_var_32_sve2:
++.Loop_var_32_sve2:
+     sub             w12, w12, #1
+     ld1             {v4.16b-v5.16b}, [x0], x1
+     pixel_var_1 v4
+     pixel_var_1 v5
+-    cbnz            w12, .loop_var_32_sve2
++    cbnz            w12, .Loop_var_32_sve2
+     pixel_var_end
+     ret
+ .vl_gt_16_pixel_var_32x32:
+@@ -150,14 +150,14 @@ function PFX(pixel_var_64x64_sve2)
+     bgt             .vl_gt_16_pixel_var_64x64
+     pixel_var_start
+     mov             w12, #64
+-.loop_var_64_sve2:
++.Loop_var_64_sve2:
+     sub             w12, w12, #1
+     ld1             {v4.16b-v7.16b}, [x0], x1
+     pixel_var_1 v4
+     pixel_var_1 v5
+     pixel_var_1 v6
+     pixel_var_1 v7
+-    cbnz            w12, .loop_var_64_sve2
++    cbnz            w12, .Loop_var_64_sve2
+     pixel_var_end
+     ret
+ .vl_gt_16_pixel_var_64x64:
+@@ -268,7 +268,7 @@ function PFX(getResidual32_sve2)
+     bgt             .vl_gt_16_getResidual32
+     lsl             x4, x3, #1
+     mov             w12, #4
+-.loop_residual_32:
++.Loop_residual_32:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v1.16b}, [x0], x3
+@@ -286,7 +286,7 @@ function PFX(getResidual32_sve2)
+     st1             {v16.8h-v19.8h}, [x2], x4
+     st1             {v20.8h-v23.8h}, [x2], x4
+ .endr
+-    cbnz            w12, .loop_residual_32
++    cbnz            w12, .Loop_residual_32
+     ret
+ .vl_gt_16_getResidual32:
+     cmp             x9, #48
+@@ -323,7 +323,7 @@ function PFX(pixel_sub_ps_32x32_sve2)
+     bgt             .vl_gt_16_pixel_sub_ps_32x32
+     lsl             x1, x1, #1
+     mov             w12, #4
+-.loop_sub_ps_32_sve2:
++.Loop_sub_ps_32_sve2:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v1.16b}, [x2], x4
+@@ -341,7 +341,7 @@ function PFX(pixel_sub_ps_32x32_sve2)
+     st1             {v16.8h-v19.8h}, [x0], x1
+     st1             {v20.8h-v23.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_sub_ps_32_sve2
++    cbnz            w12, .Loop_sub_ps_32_sve2
+     ret
+ .vl_gt_16_pixel_sub_ps_32x32:
+     cmp             x9, #48
+@@ -387,7 +387,7 @@ function PFX(pixel_sub_ps_64x64_sve2)
+     lsl             x1, x1, #1
+     sub             x1, x1, #64
+     mov             w12, #16
+-.loop_sub_ps_64_sve2:
++.Loop_sub_ps_64_sve2:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v3.16b}, [x2], x4
+@@ -403,7 +403,7 @@ function PFX(pixel_sub_ps_64x64_sve2)
+     st1             {v16.8h-v19.8h}, [x0], #64
+     st1             {v20.8h-v23.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_sub_ps_64_sve2
++    cbnz            w12, .Loop_sub_ps_64_sve2
+     ret
+ .vl_gt_16_pixel_sub_ps_64x64:
+     rdvl            x9, #1
+@@ -473,7 +473,7 @@ function PFX(pixel_sub_ps_32x64_sve2)
+     bgt             .vl_gt_16_pixel_sub_ps_32x64
+     lsl             x1, x1, #1
+     mov             w12, #8
+-.loop_sub_ps_32x64_sve2:
++.Loop_sub_ps_32x64_sve2:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v1.16b}, [x2], x4
+@@ -491,7 +491,7 @@ function PFX(pixel_sub_ps_32x64_sve2)
+     st1             {v16.8h-v19.8h}, [x0], x1
+     st1             {v20.8h-v23.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_sub_ps_32x64_sve2
++    cbnz            w12, .Loop_sub_ps_32x64_sve2
+     ret
+ .vl_gt_16_pixel_sub_ps_32x64:
+     cmp             x9, #48
+@@ -609,7 +609,7 @@ pixel_add_ps_16xN_sve2 32
+     bgt             .vl_gt_16_pixel_add_ps_32x\h
+     lsl             x5, x5, #1
+     mov             w12, #\h / 4
+-.loop_add_ps__sve2_32x\h\():
++.Loop_add_ps__sve2_32x\h\():
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v1.16b}, [x2], x4
+@@ -628,7 +628,7 @@ pixel_add_ps_16xN_sve2 32
+     sqxtun2         v5.16b, v27.8h
+     st1             {v4.16b-v5.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_add_ps__sve2_32x\h
++    cbnz            w12, .Loop_add_ps__sve2_32x\h
+     ret
+ .vl_gt_16_pixel_add_ps_32x\h\():
+     cmp             x9, #48
+@@ -1157,7 +1157,7 @@ function PFX(ssimDist16_sve2)
+     bgt             .vl_gt_16_ssimDist16
+     ssimDist_start
+     ptrue           p0.s, vl4
+-.loop_ssimDist16_sve2:
++.Loop_ssimDist16_sve2:
+     sub             w12, w12, #1
+     ld1b            {z4.s}, p0/z, [x0]
+     ld1b            {z5.s}, p0/z, [x0, #1, mul vl]
+@@ -1171,7 +1171,7 @@ function PFX(ssimDist16_sve2)
+     add             x2, x2, x3
+     ssimDist_1_sve2 z4, z5, z8, z9
+     ssimDist_1_sve2 z6, z7, z10, z11
+-    cbnz            w12, .loop_ssimDist16_sve2
++    cbnz            w12, .Loop_ssimDist16_sve2
+     ssimDist_end
+     ret
+ .vl_gt_16_ssimDist16:
+@@ -1217,7 +1217,7 @@ function PFX(ssimDist32_sve2)
+     bgt             .vl_gt_16_ssimDist32
+     ssimDist_start
+     ptrue           p0.s, vl4
+-.loop_ssimDist32_sve2:
++.Loop_ssimDist32_sve2:
+     sub             w12, w12, #1
+     ld1b            {z2.s}, p0/z, [x0]
+     ld1b            {z3.s}, p0/z, [x0, #1, mul vl]
+@@ -1241,7 +1241,7 @@ function PFX(ssimDist32_sve2)
+     ssimDist_1_sve2 z4, z5, z12, z13
+     ssimDist_1_sve2 z6, z7, z14, z15
+     ssimDist_1_sve2 z8, z9, z30, z31
+-    cbnz            w12, .loop_ssimDist32_sve2
++    cbnz            w12, .Loop_ssimDist32_sve2
+     ssimDist_end
+     ret
+ .vl_gt_16_ssimDist32:
+@@ -1309,7 +1309,7 @@ function PFX(ssimDist64_sve2)
+     bgt             .vl_gt_16_ssimDist64
+     ssimDist_start
+     ptrue           p0.s, vl4
+-.loop_ssimDist64_sve2:
++.Loop_ssimDist64_sve2:
+     sub             w12, w12, #1
+     ld1b            {z2.s}, p0/z, [x0]
+     ld1b            {z3.s}, p0/z, [x0, #1, mul vl]
+@@ -1357,7 +1357,7 @@ function PFX(ssimDist64_sve2)
+     ssimDist_1_sve2 z8, z9, z29, z30
+     add             x0, x0, x1
+     add             x2, x2, x3
+-    cbnz            w12, .loop_ssimDist64_sve2
++    cbnz            w12, .Loop_ssimDist64_sve2
+     ssimDist_end
+     ret
+ .vl_gt_16_ssimDist64:
+@@ -1482,7 +1482,7 @@ function PFX(normFact16_sve2)
+     bgt             .vl_gt_16_normFact16
+     normFact_start
+     ptrue           p0.s, vl4
+-.loop_normFact16_sve2:
++.Loop_normFact16_sve2:
+     sub             w12, w12, #1
+     ld1b            {z4.s}, p0/z, [x0]
+     ld1b            {z5.s}, p0/z, [x0, #1, mul vl]
+@@ -1491,7 +1491,7 @@ function PFX(normFact16_sve2)
+     add             x0, x0, x1
+     normFact_1_sve2 z4, z5
+     normFact_1_sve2 z6, z7
+-    cbnz            w12, .loop_normFact16_sve2
++    cbnz            w12, .Loop_normFact16_sve2
+     normFact_end
+     ret
+ .vl_gt_16_normFact16:
+@@ -1529,7 +1529,7 @@ function PFX(normFact32_sve2)
+     bgt             .vl_gt_16_normFact32
+     normFact_start
+     ptrue           p0.s, vl4
+-.loop_normFact32_sve2:
++.Loop_normFact32_sve2:
+     sub             w12, w12, #1
+     ld1b            {z4.s}, p0/z, [x0]
+     ld1b            {z5.s}, p0/z, [x0, #1, mul vl]
+@@ -1544,7 +1544,7 @@ function PFX(normFact32_sve2)
+     normFact_1_sve2 z6, z7
+     normFact_1_sve2 z8, z9
+     normFact_1_sve2 z10, z11
+-    cbnz            w12, .loop_normFact32_sve2
++    cbnz            w12, .Loop_normFact32_sve2
+     normFact_end
+     ret
+ .vl_gt_16_normFact32:
+@@ -1599,7 +1599,7 @@ function PFX(normFact64_sve2)
+     bgt             .vl_gt_16_normFact64
+     normFact_start
+     ptrue           p0.s, vl4
+-.loop_normFact64_sve2:
++.Loop_normFact64_sve2:
+     sub             w12, w12, #1
+     ld1b            {z4.s}, p0/z, [x0]
+     ld1b            {z5.s}, p0/z, [x0, #1, mul vl]
+@@ -1628,7 +1628,7 @@ function PFX(normFact64_sve2)
+     normFact_1_sve2 z8, z9
+     normFact_1_sve2 z10, z11
+     add             x0, x0, x1
+-    cbnz            w12, .loop_normFact64_sve2
++    cbnz            w12, .Loop_normFact64_sve2
+     normFact_end
+     ret
+ .vl_gt_16_normFact64:
+diff --git a/source/common/aarch64/pixel-util.S b/source/common/aarch64/pixel-util.S
+index 9b3c11504..1df49ba6e 100644
+--- a/source/common/aarch64/pixel-util.S
++++ b/source/common/aarch64/pixel-util.S
+@@ -60,11 +60,11 @@ endfunc
+ function PFX(pixel_var_16x16_neon)
+     pixel_var_start
+     mov             w12, #16
+-.loop_var_16:
++.Loop_var_16:
+     sub             w12, w12, #1
+     ld1             {v4.16b}, [x0], x1
+     pixel_var_1 v4
+-    cbnz            w12, .loop_var_16
++    cbnz            w12, .Loop_var_16
+     pixel_var_end
+     ret
+ endfunc
+@@ -72,12 +72,12 @@ endfunc
+ function PFX(pixel_var_32x32_neon)
+     pixel_var_start
+     mov             w12, #32
+-.loop_var_32:
++.Loop_var_32:
+     sub             w12, w12, #1
+     ld1             {v4.16b-v5.16b}, [x0], x1
+     pixel_var_1 v4
+     pixel_var_1 v5
+-    cbnz            w12, .loop_var_32
++    cbnz            w12, .Loop_var_32
+     pixel_var_end
+     ret
+ endfunc
+@@ -85,14 +85,14 @@ endfunc
+ function PFX(pixel_var_64x64_neon)
+     pixel_var_start
+     mov             w12, #64
+-.loop_var_64:
++.Loop_var_64:
+     sub             w12, w12, #1
+     ld1             {v4.16b-v7.16b}, [x0], x1
+     pixel_var_1 v4
+     pixel_var_1 v5
+     pixel_var_1 v6
+     pixel_var_1 v7
+-    cbnz            w12, .loop_var_64
++    cbnz            w12, .Loop_var_64
+     pixel_var_end
+     ret
+ endfunc
+@@ -148,7 +148,7 @@ endfunc
+ function PFX(getResidual32_neon)
+     lsl             x4, x3, #1
+     mov             w12, #4
+-.loop_residual_32:
++.Loop_residual_32:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v1.16b}, [x0], x3
+@@ -166,7 +166,7 @@ function PFX(getResidual32_neon)
+     st1             {v16.8h-v19.8h}, [x2], x4
+     st1             {v20.8h-v23.8h}, [x2], x4
+ .endr
+-    cbnz            w12, .loop_residual_32
++    cbnz            w12, .Loop_residual_32
+     ret
+ endfunc
+ 
+@@ -221,7 +221,7 @@ endfunc
+ function PFX(pixel_sub_ps_32x32_neon)
+     lsl             x1, x1, #1
+     mov             w12, #4
+-.loop_sub_ps_32:
++.Loop_sub_ps_32:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v1.16b}, [x2], x4
+@@ -239,7 +239,7 @@ function PFX(pixel_sub_ps_32x32_neon)
+     st1             {v16.8h-v19.8h}, [x0], x1
+     st1             {v20.8h-v23.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_sub_ps_32
++    cbnz            w12, .Loop_sub_ps_32
+     ret
+ endfunc
+ 
+@@ -247,7 +247,7 @@ function PFX(pixel_sub_ps_64x64_neon)
+     lsl             x1, x1, #1
+     sub             x1, x1, #64
+     mov             w12, #16
+-.loop_sub_ps_64:
++.Loop_sub_ps_64:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v3.16b}, [x2], x4
+@@ -263,7 +263,7 @@ function PFX(pixel_sub_ps_64x64_neon)
+     st1             {v16.8h-v19.8h}, [x0], #64
+     st1             {v20.8h-v23.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_sub_ps_64
++    cbnz            w12, .Loop_sub_ps_64
+     ret
+ endfunc
+ 
+@@ -318,7 +318,7 @@ endfunc
+ function PFX(pixel_sub_ps_32x64_neon)
+     lsl             x1, x1, #1
+     mov             w12, #8
+-.loop_sub_ps_32x64:
++.Loop_sub_ps_32x64:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v1.16b}, [x2], x4
+@@ -336,7 +336,7 @@ function PFX(pixel_sub_ps_32x64_neon)
+     st1             {v16.8h-v19.8h}, [x0], x1
+     st1             {v20.8h-v23.8h}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_sub_ps_32x64
++    cbnz            w12, .Loop_sub_ps_32x64
+     ret
+ endfunc
+ 
+@@ -383,7 +383,7 @@ endfunc
+ function PFX(pixel_add_ps_16x\h\()_neon)
+     lsl             x5, x5, #1
+     mov             w12, #\h / 8
+-.loop_add_ps_16x\h\():
++.Loop_add_ps_16x\h\():
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b}, [x2], x4
+@@ -405,7 +405,7 @@ function PFX(pixel_add_ps_16x\h\()_neon)
+     st1             {v4.16b}, [x0], x1
+     st1             {v5.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_add_ps_16x\h
++    cbnz            w12, .Loop_add_ps_16x\h
+     ret
+ endfunc
+ .endm
+@@ -417,7 +417,7 @@ pixel_add_ps_16xN_neon 32
+  function PFX(pixel_add_ps_32x\h\()_neon)
+     lsl             x5, x5, #1
+     mov             w12, #\h / 4
+-.loop_add_ps_32x\h\():
++.Loop_add_ps_32x\h\():
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v0.16b-v1.16b}, [x2], x4
+@@ -436,7 +436,7 @@ pixel_add_ps_16xN_neon 32
+     sqxtun2         v5.16b, v27.8h
+     st1             {v4.16b-v5.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_add_ps_32x\h
++    cbnz            w12, .Loop_add_ps_32x\h
+     ret
+ endfunc
+ .endm
+@@ -448,7 +448,7 @@ function PFX(pixel_add_ps_64x64_neon)
+     lsl             x5, x5, #1
+     sub             x5, x5, #64
+     mov             w12, #32
+-.loop_add_ps_64x64:
++.Loop_add_ps_64x64:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v0.16b-v3.16b}, [x2], x4
+@@ -480,7 +480,7 @@ function PFX(pixel_add_ps_64x64_neon)
+     sqxtun2         v3.16b, v7.8h
+     st1             {v0.16b-v3.16b}, [x0], x1
+ .endr
+-    cbnz            w12, .loop_add_ps_64x64
++    cbnz            w12, .Loop_add_ps_64x64
+     ret
+ endfunc
+ 
+@@ -548,7 +548,7 @@ endfunc
+ // void scale2D_64to32(pixel* dst, const pixel* src, intptr_t stride)
+ function PFX(scale2D_64to32_neon)
+     mov             w12, #32
+-.loop_scale2D:
++.Loop_scale2D:
+     ld1             {v0.16b-v3.16b}, [x1], x2
+     sub             w12, w12, #1
+     ld1             {v4.16b-v7.16b}, [x1], x2
+@@ -561,7 +561,7 @@ function PFX(scale2D_64to32_neon)
+     uqrshrn         v1.8b, v2.8h, #2
+     uqrshrn2        v1.16b, v3.8h, #2
+     st1             {v0.16b-v1.16b}, [x0], #32
+-    cbnz            w12, .loop_scale2D
++    cbnz            w12, .Loop_scale2D
+     ret
+ endfunc
+ 
+@@ -569,33 +569,33 @@ endfunc
+ function PFX(pixel_planecopy_cp_neon)
+     dup             v2.16b, w6
+     sub             x5, x5, #1
+-.loop_h:
++.Loop_h:
+     mov             x6, x0
+     mov             x12, x2
+     mov             x7, #0
+-.loop_w:
++.Loop_w:
+     ldr             q0, [x6], #16
+     ushl            v0.16b, v0.16b, v2.16b
+     str             q0, [x12], #16
+     add             x7, x7, #16
+     cmp             x7, x4
+-    blt             .loop_w
++    blt             .Loop_w
+ 
+     add             x0, x0, x1
+     add             x2, x2, x3
+     sub             x5, x5, #1
+-    cbnz            x5, .loop_h
++    cbnz            x5, .Loop_h
+ 
+ // handle last row
+     mov             x5, x4
+     lsr             x5, x5, #3
+-.loopW8:
++.LoopW8:
+     ldr             d0, [x0], #8
+     ushl            v0.8b, v0.8b, v2.8b
+     str             d0, [x2], #8
+     sub             x4, x4, #8
+     sub             x5, x5, #1
+-    cbnz            x5, .loopW8
++    cbnz            x5, .LoopW8
+ 
+     mov             x5, #8
+     sub             x5, x5, x4
+@@ -1508,7 +1508,7 @@ function PFX(pixel_sa8d_32x64_neon)
+     mov             x10, x30
+     mov             w11, #4
+     mov             w9, #0
+-.loop_sa8d_32:
++.Loop_sa8d_32:
+     sub             w11, w11, #1
+     sa8d_16x16      w4
+     sub             x0, x0, x1, lsl #4
+@@ -1520,7 +1520,7 @@ function PFX(pixel_sa8d_32x64_neon)
+     add             w9, w9, w4
+     sub             x0, x0, #24
+     sub             x2, x2, #24
+-    cbnz            w11, .loop_sa8d_32
++    cbnz            w11, .Loop_sa8d_32
+     mov             w0, w9
+     ret             x10
+ endfunc
+@@ -1529,7 +1529,7 @@ function PFX(pixel_sa8d_64x64_neon)
+     mov             x10, x30
+     mov             w11, #4
+     mov             w9, #0
+-.loop_sa8d_64:
++.Loop_sa8d_64:
+     sub             w11, w11, #1
+     sa8d_16x16      w4
+     sub             x0, x0, x1, lsl #4
+@@ -1554,7 +1554,7 @@ function PFX(pixel_sa8d_64x64_neon)
+ 
+     sub             x0, x0, #56
+     sub             x2, x2, #56
+-    cbnz            w11, .loop_sa8d_64
++    cbnz            w11, .Loop_sa8d_64
+     mov             w0, w9
+     ret             x10
+ endfunc
+@@ -1807,7 +1807,7 @@ function PFX(quant_neon)
+     eor             w10, w10, w10
+     eor             v17.16b, v17.16b, v17.16b
+ 
+-.loop_quant:
++.Loop_quant:
+ 
+     ld1             {v18.4h}, [x0], #8
+     ld1             {v7.4s}, [x1], #16
+@@ -1839,7 +1839,7 @@ function PFX(quant_neon)
+     st1             {v5.4h}, [x3], #8
+ 
+     subs            w6, w6, #1
+-    b.ne             .loop_quant
++    b.ne             .Loop_quant
+ 
+     addv            s4, v4.4s
+     mov             w9, v4.s[0]
+@@ -1858,7 +1858,7 @@ function PFX(nquant_neon)
+     mov             x4, #0
+     movi            v22.4s, #0
+ 
+-.loop_nquant:
++.Loop_nquant:
+     ld1             {v16.4h}, [x0], #8
+     sub             w5, w5, #1
+     sxtl            v19.4s, v16.4h         // v19 = coef[blockpos]
+@@ -1883,7 +1883,7 @@ function PFX(nquant_neon)
+     abs             v17.4h, v16.4h
+     st1             {v17.4h}, [x2], #8
+ 
+-    cbnz            w5, .loop_nquant
++    cbnz            w5, .Loop_nquant
+ 
+     uaddlv          d4, v4.4s
+     fmov            x12, d4
+@@ -1937,7 +1937,7 @@ endfunc
+ function PFX(ssimDist16_neon)
+     mov w12, #16
+     ssimDist_start
+-.loop_ssimDist16:
++.Loop_ssimDist16:
+     sub             w12, w12, #1
+     ld1             {v4.16b}, [x0], x1
+     ld1             {v5.16b}, [x2], x3
+@@ -1947,7 +1947,7 @@ function PFX(ssimDist16_neon)
+     uxtl2           v5.8h, v5.16b
+     ssimDist_1      v6, v7
+     ssimDist_1      v4, v5
+-    cbnz            w12, .loop_ssimDist16
++    cbnz            w12, .Loop_ssimDist16
+     ssimDist_end
+     ret
+ endfunc
+@@ -1955,7 +1955,7 @@ endfunc
+ function PFX(ssimDist32_neon)
+     mov w12, #32
+     ssimDist_start
+-.loop_ssimDist32:
++.Loop_ssimDist32:
+     sub             w12, w12, #1
+     ld1             {v4.16b-v5.16b}, [x0], x1
+     ld1             {v6.16b-v7.16b}, [x2], x3
+@@ -1971,7 +1971,7 @@ function PFX(ssimDist32_neon)
+     ssimDist_1      v23, v24
+     ssimDist_1      v25, v26
+     ssimDist_1      v27, v28
+-    cbnz            w12, .loop_ssimDist32
++    cbnz            w12, .Loop_ssimDist32
+     ssimDist_end
+     ret
+ endfunc
+@@ -1979,7 +1979,7 @@ endfunc
+ function PFX(ssimDist64_neon)
+     mov w12, #64
+     ssimDist_start
+-.loop_ssimDist64:
++.Loop_ssimDist64:
+     sub             w12, w12, #1
+     ld1             {v4.16b-v7.16b}, [x0], x1
+     ld1             {v16.16b-v19.16b}, [x2], x3
+@@ -2007,7 +2007,7 @@ function PFX(ssimDist64_neon)
+     ssimDist_1      v23, v24
+     ssimDist_1      v25, v26
+     ssimDist_1      v27, v28
+-    cbnz            w12, .loop_ssimDist64
++    cbnz            w12, .Loop_ssimDist64
+     ssimDist_end
+     ret
+ endfunc
+@@ -2035,14 +2035,14 @@ endfunc
+ function PFX(normFact16_neon)
+     mov w12, #16
+     normFact_start
+-.loop_normFact16:
++.Loop_normFact16:
+     sub             w12, w12, #1
+     ld1             {v4.16b}, [x0], x1
+     uxtl            v5.8h, v4.8b
+     uxtl2           v4.8h, v4.16b
+     normFact_1      v5
+     normFact_1      v4
+-    cbnz            w12, .loop_normFact16
++    cbnz            w12, .Loop_normFact16
+     normFact_end
+     ret
+ endfunc
+@@ -2050,7 +2050,7 @@ endfunc
+ function PFX(normFact32_neon)
+     mov w12, #32
+     normFact_start
+-.loop_normFact32:
++.Loop_normFact32:
+     sub             w12, w12, #1
+     ld1             {v4.16b-v5.16b}, [x0], x1
+     uxtl            v6.8h, v4.8b
+@@ -2061,7 +2061,7 @@ function PFX(normFact32_neon)
+     normFact_1      v5
+     normFact_1      v6
+     normFact_1      v7
+-    cbnz            w12, .loop_normFact32
++    cbnz            w12, .Loop_normFact32
+     normFact_end
+     ret
+ endfunc
+@@ -2069,7 +2069,7 @@ endfunc
+ function PFX(normFact64_neon)
+     mov w12, #64
+     normFact_start
+-.loop_normFact64:
++.Loop_normFact64:
+     sub             w12, w12, #1
+     ld1             {v4.16b-v7.16b}, [x0], x1
+     uxtl            v26.8h, v4.8b
+@@ -2088,7 +2088,7 @@ function PFX(normFact64_neon)
+     normFact_1      v25
+     normFact_1      v26
+     normFact_1      v27
+-    cbnz            w12, .loop_normFact64
++    cbnz            w12, .Loop_normFact64
+     normFact_end
+     ret
+ endfunc
+@@ -2120,9 +2120,9 @@ function PFX(weight_pp_neon)
+     cbnz            w11, .widenTo32Bit
+ 
+     // 16-bit arithmetic is enough.
+-.loopHpp:
++.LoopHpp:
+     mov             x12, x3
+-.loopWpp:
++.LoopWpp:
+     ldr             q0, [x0], #16
+     sub             x12, x12, #16
+     umull           v1.8h, v0.8b, v25.8b  // val *= w0 << correction >> shift
+@@ -2132,18 +2132,18 @@ function PFX(weight_pp_neon)
+     sqxtun          v0.8b, v1.8h          // val = x265_clip(val)
+     sqxtun2         v0.16b, v2.8h
+     str             q0, [x1], #16
+-    cbnz            x12, .loopWpp
++    cbnz            x12, .LoopWpp
+     add             x1, x1, x2
+     add             x0, x0, x2
+     sub             x4, x4, #1
+-    cbnz            x4, .loopHpp
++    cbnz            x4, .LoopHpp
+     ret
+ 
+     // 32-bit arithmetic is needed.
+ .widenTo32Bit:
+-.loopHpp32:
++.LoopHpp32:
+     mov             x12, x3
+-.loopWpp32:
++.LoopWpp32:
+     ldr             d0, [x0], #8
+     sub             x12, x12, #8
+     uxtl            v0.8h, v0.8b
+@@ -2155,11 +2155,11 @@ function PFX(weight_pp_neon)
+     sqxtn2          v0.8h, v2.4s
+     sqxtun          v0.8b, v0.8h
+     str             d0, [x1], #8
+-    cbnz            x12, .loopWpp32
++    cbnz            x12, .LoopWpp32
+     add             x1, x1, x2
+     add             x0, x0, x2
+     sub             x4, x4, #1
+-    cbnz            x4, .loopHpp32
++    cbnz            x4, .LoopHpp32
+     ret
+ 
+     // The shift right cannot be moved out of the loop.
+@@ -2169,9 +2169,9 @@ function PFX(weight_pp_neon)
+     neg             w7, w7                // -shift
+     dup             v27.4s, w7
+     dup             v29.4s, w9            // offset
+-.loopHppUS:
++.LoopHppUS:
+     mov             x12, x3
+-.loopWppUS:
++.LoopWppUS:
+     ldr             d0, [x0], #8
+     sub             x12, x12, #8
+     uxtl            v0.8h, v0.8b
+@@ -2187,11 +2187,11 @@ function PFX(weight_pp_neon)
+     sqxtn2          v0.8h, v2.4s
+     sqxtun          v0.8b, v0.8h
+     str             d0, [x1], #8
+-    cbnz            x12, .loopWppUS
++    cbnz            x12, .LoopWppUS
+     add             x1, x1, x2
+     add             x0, x0, x2
+     sub             x4, x4, #1
+-    cbnz            x4, .loopHppUS
++    cbnz            x4, .LoopHppUS
+     ret
+ endfunc
+ 
+@@ -2220,7 +2220,7 @@ function PFX(scanPosLast_neon)
+     add             x11, x10, x7    // 3*x7
+     add             x9, x4, #1      // CG count
+ 
+-.loop_spl:
++.Loop_spl:
+     // position of current CG
+     ldrh            w6, [x0], #32
+     add             x6, x1, x6, lsl #1
+@@ -2267,14 +2267,14 @@ function PFX(scanPosLast_neon)
+     // accelerate by preparing w13 = w13 & w15
+     and             w13, w13, w15
+     mov             x14, xzr
+-.loop_spl_1:
++.Loop_spl_1:
+     cbz             w15, .pext_end
+     clz             w6, w15
+     lsl             w13, w13, w6
+     lsl             w15, w15, w6
+     extr            w14, w14, w13, #31
+     bfm             w15, wzr, #1, #0
+-    b               .loop_spl_1
++    b               .Loop_spl_1
+ .pext_end:
+     strh            w14, [x2], #2
+ 
+@@ -2285,7 +2285,7 @@ function PFX(scanPosLast_neon)
+     sub             x5, x5, x6
+     strb            w6, [x4], #1
+ 
+-    cbnz            x5, .loop_spl
++    cbnz            x5, .Loop_spl
+ 
+     // count trailing zeros
+     rbit            w13, w12
+@@ -2311,7 +2311,7 @@ endfunc
+ //    uint8_t *baseCtx,      // x6
+ //    int offset,            // x7
+ //    int scanPosSigOff,     // sp
+-//    int subPosBase)        // sp + 8
++//    int subPosBase)        // sp + 8, or sp + 4 on APPLE
+ function PFX(costCoeffNxN_neon)
+     // abs(coeff)
+     add             x2, x2, x2
+@@ -2364,7 +2364,7 @@ function PFX(costCoeffNxN_neon)
+     mov             x11, #0
+     movi            v31.16b, #0
+     cbz             x2, .idx_zero
+-.loop_ccnn:
++.Loop_ccnn:
+ //   {
+ //        const uint32_t cnt = tabSigCtx[blkPos] + offset + posOffset;
+ //        ctxSig = cnt & posZeroMask;
+@@ -2403,14 +2403,14 @@ function PFX(costCoeffNxN_neon)
+     cmp             w9, #1
+     csel            w10, w11, w10, eq
+     strb            w10, [x6, x14]
+-    cbnz            x2, .loop_ccnn
++    cbnz            x2, .Loop_ccnn
+ .idx_zero:
+ 
+     add             x13, x3, x4, lsl #1
+     add             x4, x4, x15
+     str             h2, [x13]              // absCoeff[numNonZero] = tmpCoeff[blkPos]
+ 
+-    ldr             x9, [sp, #8]           // subPosBase
++    ldr             x9, [sp, #STACK_ARG_OFFSET(1)]           // subPosBase
+     uxth            w9, w9
+     cmp             w9, #0
+     cset            x2, eq
+diff --git a/source/common/aarch64/sad-a-sve2.S b/source/common/aarch64/sad-a-sve2.S
+index 9c86d84b6..599a3719a 100644
+--- a/source/common/aarch64/sad-a-sve2.S
++++ b/source/common/aarch64/sad-a-sve2.S
+@@ -217,12 +217,12 @@ function PFX(pixel_sad_\w\()x\h\()_sve2)
+     SAD_START_\w
+ 
+     mov             w9, #\h/8
+-.loop_sve2_\w\()x\h:
++.Loop_sve2_\w\()x\h:
+     sub             w9, w9, #1
+ .rept 4
+     SAD_\w
+ .endr
+-    cbnz            w9, .loop_sve2_\w\()x\h
++    cbnz            w9, .Loop_sve2_\w\()x\h
+ 
+     SAD_END_\w
+ 
+@@ -231,12 +231,12 @@ function PFX(pixel_sad_\w\()x\h\()_sve2)
+     SAD_START_\w
+ 
+     mov             w9, #\h/8
+-.loop_sve2_loop_\w\()x\h:
++.Loop_sve2_loop_\w\()x\h:
+     sub             w9, w9, #1
+ .rept 4
+     SAD_\w
+ .endr
+-    cbnz            w9, .loop_sve2_loop_\w\()x\h
++    cbnz            w9, .Loop_sve2_loop_\w\()x\h
+ 
+     SAD_END_\w
+ .else
+@@ -402,7 +402,7 @@ function PFX(sad_x\x\()_\w\()x\h\()_sve2)
+     bgt             .vl_gt_16_sad_x_loop_\x\()_\w\()x\h
+     SAD_X_START_\w \x
+     mov             w12, #\h/4
+-.loop_sad_sve2_x\x\()_\w\()x\h:
++.Loop_sad_sve2_x\x\()_\w\()x\h:
+     sub             w12, w12, #1
+  .rept 4
+   .if \w == 24
+@@ -422,7 +422,7 @@ function PFX(sad_x\x\()_\w\()x\h\()_sve2)
+     SAD_X_\w x4, v19, v23
+   .endif
+  .endr
+-    cbnz            w12, .loop_sad_sve2_x\x\()_\w\()x\h
++    cbnz            w12, .Loop_sad_sve2_x\x\()_\w\()x\h
+     SAD_X_END_\w \x
+ .vl_gt_16_sad_x_loop_\x\()_\w\()x\h\():
+ .if \w == 24 || \w == 32
+@@ -431,7 +431,7 @@ function PFX(sad_x\x\()_\w\()x\h\()_sve2)
+ .else
+     SAD_X_START_\w \x
+     mov             w12, #\h/4
+-.loop_sad_sve2_gt_16_x\x\()_\w\()x\h:
++.Loop_sad_sve2_gt_16_x\x\()_\w\()x\h:
+     sub             w12, w12, #1
+  .rept 4
+   .if \w == 24
+@@ -451,7 +451,7 @@ function PFX(sad_x\x\()_\w\()x\h\()_sve2)
+     SAD_X_\w x4, v19, v23
+   .endif
+  .endr
+-    cbnz            w12, .loop_sad_sve2_gt_16_x\x\()_\w\()x\h
++    cbnz            w12, .Loop_sad_sve2_gt_16_x\x\()_\w\()x\h
+     SAD_X_END_\w \x
+ .endif
+ endfunc
+diff --git a/source/common/aarch64/sad-a.S b/source/common/aarch64/sad-a.S
+index 20d7cac7c..7460825f1 100644
+--- a/source/common/aarch64/sad-a.S
++++ b/source/common/aarch64/sad-a.S
+@@ -55,12 +55,12 @@ function PFX(pixel_sad_\w\()x\h\()_neon)
+     SAD_START_\w
+ 
+     mov             w9, #\h/8
+-.loop_\w\()x\h:
++.Loop_\w\()x\h:
+     sub             w9, w9, #1
+ .rept 4
+     SAD_\w
+ .endr
+-    cbnz            w9, .loop_\w\()x\h
++    cbnz            w9, .Loop_\w\()x\h
+ 
+     SAD_END_\w
+ endfunc
+@@ -129,7 +129,7 @@ function PFX(sad_x\x\()_\w\()x\h\()_neon)
+ .endif
+     SAD_X_START_\w \x
+     mov             w12, #\h/4
+-.loop_sad_x\x\()_\w\()x\h:
++.Loop_sad_x\x\()_\w\()x\h:
+     sub             w12, w12, #1
+  .rept 4
+   .if \w == 24
+@@ -149,7 +149,7 @@ function PFX(sad_x\x\()_\w\()x\h\()_neon)
+     SAD_X_\w x4, v19, v23
+   .endif
+  .endr
+-    cbnz            w12, .loop_sad_x\x\()_\w\()x\h
++    cbnz            w12, .Loop_sad_x\x\()_\w\()x\h
+     SAD_X_END_\w \x
+ endfunc
+ .endm
+diff --git a/source/common/aarch64/sao-prim-sve.cpp b/source/common/aarch64/sao-prim-sve.cpp
+new file mode 100644
+index 000000000..4b9e3c5d2
+--- /dev/null
++++ b/source/common/aarch64/sao-prim-sve.cpp
+@@ -0,0 +1,298 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: Hari Limaye <hari.limaye@arm.com>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#include "sao-prim.h"
++#include <arm_neon_sve_bridge.h>
++
++/* We can access instructions that are exclusive to the SVE instruction set from
++ * a predominantly Neon context by making use of the Neon-SVE bridge intrinsics
++ * to reinterpret Neon vectors as SVE vectors - with the high part of the SVE
++ * vector (if it's longer than 128 bits) being "don't care".
++ *
++ * While sub-optimal on machines that have SVE vector length > 128-bit - as the
++ * remainder of the vector is unused - this approach is still beneficial when
++ * compared to a Neon-only implementation. */
++
++static inline int8x16_t x265_sve_mask(const int x, const int endX,
++                                      const int8x16_t in)
++{
++    // Use predicate to shift "unused lanes" outside of range [-2, 2]
++    svbool_t svpred = svwhilelt_b8(x, endX);
++    svint8_t edge_type = svsel_s8(svpred, svset_neonq_s8(svundef_s8(), in),
++                                  svdup_n_s8(-3));
++    return svget_neonq_s8(edge_type);
++}
++
++static inline int64x2_t x265_sdotq_s16(int64x2_t acc, int16x8_t x, int16x8_t y)
++{
++    return svget_neonq_s64(svdot_s64(svset_neonq_s64(svundef_s64(), acc),
++                                     svset_neonq_s16(svundef_s16(), x),
++                                     svset_neonq_s16(svundef_s16(), y)));
++}
++
++/*
++ * Compute Edge Offset statistics (count and stats).
++ * To save some instructions compute count and stats as negative values - since
++ * output of Neon comparison instructions for a matched condition is all 1s (-1).
++ */
++static inline void compute_eo_stats(const int8x16_t edge_type,
++                                    const int16_t *diff, int16x8_t *count,
++                                    int64x2_t *stats)
++{
++    // Create a mask for each edge type.
++    int8x16_t mask0 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(-2)));
++    int8x16_t mask1 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(-1)));
++    int8x16_t mask2 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(0)));
++    int8x16_t mask3 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(1)));
++    int8x16_t mask4 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(2)));
++
++    // Compute negative counts for each edge type.
++    count[0] = vpadalq_s8(count[0], mask0);
++    count[1] = vpadalq_s8(count[1], mask1);
++    count[2] = vpadalq_s8(count[2], mask2);
++    count[3] = vpadalq_s8(count[3], mask3);
++    count[4] = vpadalq_s8(count[4], mask4);
++
++    // Widen the masks to 16-bit.
++    int16x8_t mask0_lo = vreinterpretq_s16_s8(vzip1q_s8(mask0, mask0));
++    int16x8_t mask0_hi = vreinterpretq_s16_s8(vzip2q_s8(mask0, mask0));
++    int16x8_t mask1_lo = vreinterpretq_s16_s8(vzip1q_s8(mask1, mask1));
++    int16x8_t mask1_hi = vreinterpretq_s16_s8(vzip2q_s8(mask1, mask1));
++    int16x8_t mask2_lo = vreinterpretq_s16_s8(vzip1q_s8(mask2, mask2));
++    int16x8_t mask2_hi = vreinterpretq_s16_s8(vzip2q_s8(mask2, mask2));
++    int16x8_t mask3_lo = vreinterpretq_s16_s8(vzip1q_s8(mask3, mask3));
++    int16x8_t mask3_hi = vreinterpretq_s16_s8(vzip2q_s8(mask3, mask3));
++    int16x8_t mask4_lo = vreinterpretq_s16_s8(vzip1q_s8(mask4, mask4));
++    int16x8_t mask4_hi = vreinterpretq_s16_s8(vzip2q_s8(mask4, mask4));
++
++    int16x8_t diff_lo = vld1q_s16(diff);
++    int16x8_t diff_hi = vld1q_s16(diff + 8);
++
++    // Compute negative stats for each edge type.
++    stats[0] = x265_sdotq_s16(stats[0], diff_lo, mask0_lo);
++    stats[0] = x265_sdotq_s16(stats[0], diff_hi, mask0_hi);
++    stats[1] = x265_sdotq_s16(stats[1], diff_lo, mask1_lo);
++    stats[1] = x265_sdotq_s16(stats[1], diff_hi, mask1_hi);
++    stats[2] = x265_sdotq_s16(stats[2], diff_lo, mask2_lo);
++    stats[2] = x265_sdotq_s16(stats[2], diff_hi, mask2_hi);
++    stats[3] = x265_sdotq_s16(stats[3], diff_lo, mask3_lo);
++    stats[3] = x265_sdotq_s16(stats[3], diff_hi, mask3_hi);
++    stats[4] = x265_sdotq_s16(stats[4], diff_lo, mask4_lo);
++    stats[4] = x265_sdotq_s16(stats[4], diff_hi, mask4_hi);
++}
++
++/*
++ * Reduce and store Edge Offset statistics (count and stats).
++ */
++static inline void reduce_eo_stats(int64x2_t *vstats, int16x8_t *vcount,
++                                   int32_t *stats, int32_t *count)
++{
++    // s_eoTable maps edge types to memory in order: {2, 0, 1, 3, 4}.
++    int16x8_t c01 = vpaddq_s16(vcount[2], vcount[0]);
++    int16x8_t c23 = vpaddq_s16(vcount[1], vcount[3]);
++    int16x8_t c0123 = vpaddq_s16(c01, c23);
++    // Subtract from current count, as we calculate the negation.
++    vst1q_s32(count, vsubq_s32(vld1q_s32(count), vpaddlq_s16(c0123)));
++    count[4] -= vaddvq_s16(vcount[4]);
++
++    int32x4_t s01 = vcombine_s32(vmovn_s64(vstats[2]), vmovn_s64(vstats[0]));
++    int32x4_t s23 = vcombine_s32(vmovn_s64(vstats[1]), vmovn_s64(vstats[3]));
++    int32x4_t s0123 = vpaddq_s32(s01, s23);
++    // Subtract from current stats, as we calculate the negation.
++    vst1q_s32(stats, vsubq_s32(vld1q_s32(stats), s0123));
++    stats[4] -= vaddvq_s64(vstats[4]);
++}
++
++namespace X265_NS {
++void saoCuStatsE0_sve(const int16_t *diff, const pixel *rec, intptr_t stride,
++                      int endX, int endY, int32_t *stats, int32_t *count)
++{
++    // Separate buffers for each edge type, so that we can vectorise.
++    int16x8_t tmp_count[5] = { vdupq_n_s16(0), vdupq_n_s16(0), vdupq_n_s16(0),
++                               vdupq_n_s16(0), vdupq_n_s16(0) };
++    int64x2_t tmp_stats[5] = { vdupq_n_s64(0), vdupq_n_s64(0), vdupq_n_s64(0),
++                               vdupq_n_s64(0), vdupq_n_s64(0) };
++
++    for (int y = 0; y < endY; y++)
++    {
++        // Calculate negated sign_left(x) directly, to save negation when
++        // reusing sign_right(x) as sign_left(x + 1).
++        int8x16_t neg_sign_left = vdupq_n_s8(x265_signOf(rec[-1] - rec[0]));
++        for (int x = 0; x < endX; x += 16)
++        {
++            int8x16_t sign_right = signOf_neon(rec + x, rec + x + 1);
++
++            // neg_sign_left(x) = sign_right(x + 1), reusing one from previous
++            // iteration.
++            neg_sign_left = vextq_s8(neg_sign_left, sign_right, 15);
++
++            // Subtract instead of add, as sign_left is negated.
++            int8x16_t edge_type = vsubq_s8(sign_right, neg_sign_left);
++
++            // For reuse in the next iteration.
++            neg_sign_left = sign_right;
++
++            edge_type = x265_sve_mask(x, endX, edge_type);
++            compute_eo_stats(edge_type, diff + x, tmp_count, tmp_stats);
++        }
++
++        diff += MAX_CU_SIZE;
++        rec += stride;
++    }
++
++    reduce_eo_stats(tmp_stats, tmp_count, stats, count);
++}
++
++void saoCuStatsE1_sve(const int16_t *diff, const pixel *rec, intptr_t stride,
++                      int8_t *upBuff1, int endX, int endY, int32_t *stats,
++                      int32_t *count)
++{
++    // Separate buffers for each edge type, so that we can vectorise.
++    int16x8_t tmp_count[5] = { vdupq_n_s16(0), vdupq_n_s16(0), vdupq_n_s16(0),
++                               vdupq_n_s16(0), vdupq_n_s16(0) };
++    int64x2_t tmp_stats[5] = { vdupq_n_s64(0), vdupq_n_s64(0), vdupq_n_s64(0),
++                               vdupq_n_s64(0), vdupq_n_s64(0) };
++
++    // Negate upBuff1 (sign_up), so we can subtract and save repeated negations.
++    for (int x = 0; x < endX; x += 16)
++    {
++        vst1q_s8(upBuff1 + x, vnegq_s8(vld1q_s8(upBuff1 + x)));
++    }
++
++    for (int y = 0; y < endY; y++)
++    {
++        for (int x = 0; x < endX; x += 16)
++        {
++            int8x16_t sign_up = vld1q_s8(upBuff1 + x);
++            int8x16_t sign_down = signOf_neon(rec + x, rec + x + stride);
++
++            // Subtract instead of add, as sign_up is negated.
++            int8x16_t edge_type = vsubq_s8(sign_down, sign_up);
++
++            // For reuse in the next iteration.
++            vst1q_s8(upBuff1 + x, sign_down);
++
++            edge_type = x265_sve_mask(x, endX, edge_type);
++            compute_eo_stats(edge_type, diff + x, tmp_count, tmp_stats);
++        }
++
++        diff += MAX_CU_SIZE;
++        rec += stride;
++    }
++
++    reduce_eo_stats(tmp_stats, tmp_count, stats, count);
++}
++
++void saoCuStatsE2_sve(const int16_t *diff, const pixel *rec, intptr_t stride,
++                      int8_t *upBuff1, int8_t *upBufft, int endX, int endY,
++                      int32_t *stats, int32_t *count)
++{
++    // Separate buffers for each edge type, so that we can vectorise.
++    int16x8_t tmp_count[5] = { vdupq_n_s16(0), vdupq_n_s16(0), vdupq_n_s16(0),
++                               vdupq_n_s16(0), vdupq_n_s16(0) };
++    int64x2_t tmp_stats[5] = { vdupq_n_s64(0), vdupq_n_s64(0), vdupq_n_s64(0),
++                               vdupq_n_s64(0), vdupq_n_s64(0) };
++
++    // Negate upBuff1 (sign_up) so we can subtract and save repeated negations.
++    for (int x = 0; x < endX; x += 16)
++    {
++        vst1q_s8(upBuff1 + x, vnegq_s8(vld1q_s8(upBuff1 + x)));
++    }
++
++    for (int y = 0; y < endY; y++)
++    {
++        upBufft[0] = x265_signOf(rec[-1] - rec[stride]);
++        for (int x = 0; x < endX; x += 16)
++        {
++            int8x16_t sign_up = vld1q_s8(upBuff1 + x);
++            int8x16_t sign_down = signOf_neon(rec + x, rec + x + stride + 1);
++
++            // Subtract instead of add, as sign_up is negated.
++            int8x16_t edge_type = vsubq_s8(sign_down, sign_up);
++
++            // For reuse in the next iteration.
++            vst1q_s8(upBufft + x + 1, sign_down);
++
++            edge_type = x265_sve_mask(x, endX, edge_type);
++            compute_eo_stats(edge_type, diff + x, tmp_count, tmp_stats);
++        }
++
++        std::swap(upBuff1, upBufft);
++
++        rec += stride;
++        diff += MAX_CU_SIZE;
++    }
++
++    reduce_eo_stats(tmp_stats, tmp_count, stats, count);
++}
++
++void saoCuStatsE3_sve(const int16_t *diff, const pixel *rec, intptr_t stride,
++                      int8_t *upBuff1, int endX, int endY, int32_t *stats,
++                      int32_t *count)
++{
++    // Separate buffers for each edge type, so that we can vectorise.
++    int16x8_t tmp_count[5] = { vdupq_n_s16(0), vdupq_n_s16(0), vdupq_n_s16(0),
++                               vdupq_n_s16(0), vdupq_n_s16(0) };
++    int64x2_t tmp_stats[5] = { vdupq_n_s64(0), vdupq_n_s64(0), vdupq_n_s64(0),
++                               vdupq_n_s64(0), vdupq_n_s64(0) };
++
++    // Negate upBuff1 (sign_up) so we can subtract and save repeated negations.
++    for (int x = 0; x < endX; x += 16)
++    {
++        vst1q_s8(upBuff1 + x, vnegq_s8(vld1q_s8(upBuff1 + x)));
++    }
++
++    for (int y = 0; y < endY; y++)
++    {
++        for (int x = 0; x < endX; x += 16)
++        {
++            int8x16_t sign_up = vld1q_s8(upBuff1 + x);
++            int8x16_t sign_down = signOf_neon(rec + x, rec + x + stride - 1);
++
++            // Subtract instead of add, as sign_up is negated.
++            int8x16_t edge_type = vsubq_s8(sign_down, sign_up);
++
++            // For reuse in the next iteration.
++            vst1q_s8(upBuff1 + x - 1, sign_down);
++
++            edge_type = x265_sve_mask(x, endX, edge_type);
++            compute_eo_stats(edge_type, diff + x, tmp_count, tmp_stats);
++        }
++
++        upBuff1[endX - 1] = x265_signOf(rec[endX] - rec[endX - 1 + stride]);
++
++        rec += stride;
++        diff += MAX_CU_SIZE;
++    }
++
++    reduce_eo_stats(tmp_stats, tmp_count, stats, count);
++}
++
++void setupSaoPrimitives_sve(EncoderPrimitives &p)
++{
++    p.saoCuStatsE0 = saoCuStatsE0_sve;
++    p.saoCuStatsE1 = saoCuStatsE1_sve;
++    p.saoCuStatsE2 = saoCuStatsE2_sve;
++    p.saoCuStatsE3 = saoCuStatsE3_sve;
++}
++} // namespace X265_NS
+diff --git a/source/common/aarch64/sao-prim.cpp b/source/common/aarch64/sao-prim.cpp
+new file mode 100644
+index 000000000..b3eda6bac
+--- /dev/null
++++ b/source/common/aarch64/sao-prim.cpp
+@@ -0,0 +1,380 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: Hari Limaye <hari.limaye@arm.com>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#include "sao-prim.h"
++#include "sao.h"
++#include <arm_neon.h>
++
++// Predicate mask indices.
++static const int8_t quad_reg_byte_indices[16] = {
++    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
++};
++
++static inline int8x16_t mask_inactive_elems(const int rem, int8x16_t edge_type)
++{
++    // Compute a predicate mask where the bits of an element are 0 if the index
++    // is less than the remainder (active), and 1 otherwise.
++    const int8x16_t indices = vld1q_s8(quad_reg_byte_indices);
++    int8x16_t pred = vreinterpretq_s8_u8(vcgeq_s8(indices, vdupq_n_s8(rem)));
++
++    // Use predicate mask to shift "unused lanes" outside of range [-2, 2]
++    pred = vshlq_n_s8(pred, 3);
++    return veorq_s8(edge_type, pred);
++}
++
++/*
++ * Compute Edge Offset statistics (count and stats).
++ * To save some instructions compute count and stats as negative values - since
++ * output of Neon comparison instructions for a matched condition is all 1s (-1).
++ */
++static inline void compute_eo_stats(const int8x16_t edge_type,
++                                    const int16_t *diff, int16x8_t *count,
++                                    int32x4_t *stats)
++{
++    // Create a mask for each edge type.
++    int8x16_t mask0 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(-2)));
++    int8x16_t mask1 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(-1)));
++    int8x16_t mask2 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(0)));
++    int8x16_t mask3 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(1)));
++    int8x16_t mask4 = vreinterpretq_s8_u8(vceqq_s8(edge_type, vdupq_n_s8(2)));
++
++    // Compute negative counts for each edge type.
++    count[0] = vpadalq_s8(count[0], mask0);
++    count[1] = vpadalq_s8(count[1], mask1);
++    count[2] = vpadalq_s8(count[2], mask2);
++    count[3] = vpadalq_s8(count[3], mask3);
++    count[4] = vpadalq_s8(count[4], mask4);
++
++    // Widen the masks to 16-bit.
++    int16x8_t mask0_lo = vreinterpretq_s16_s8(vzip1q_s8(mask0, mask0));
++    int16x8_t mask0_hi = vreinterpretq_s16_s8(vzip2q_s8(mask0, mask0));
++    int16x8_t mask1_lo = vreinterpretq_s16_s8(vzip1q_s8(mask1, mask1));
++    int16x8_t mask1_hi = vreinterpretq_s16_s8(vzip2q_s8(mask1, mask1));
++    int16x8_t mask2_lo = vreinterpretq_s16_s8(vzip1q_s8(mask2, mask2));
++    int16x8_t mask2_hi = vreinterpretq_s16_s8(vzip2q_s8(mask2, mask2));
++    int16x8_t mask3_lo = vreinterpretq_s16_s8(vzip1q_s8(mask3, mask3));
++    int16x8_t mask3_hi = vreinterpretq_s16_s8(vzip2q_s8(mask3, mask3));
++    int16x8_t mask4_lo = vreinterpretq_s16_s8(vzip1q_s8(mask4, mask4));
++    int16x8_t mask4_hi = vreinterpretq_s16_s8(vzip2q_s8(mask4, mask4));
++
++    int16x8_t diff_lo = vld1q_s16(diff);
++    int16x8_t diff_hi = vld1q_s16(diff + 8);
++
++    // Compute negative stats for each edge type.
++    int16x8_t stats0 = vmulq_s16(diff_lo, mask0_lo);
++    int16x8_t stats1 = vmulq_s16(diff_lo, mask1_lo);
++    int16x8_t stats2 = vmulq_s16(diff_lo, mask2_lo);
++    int16x8_t stats3 = vmulq_s16(diff_lo, mask3_lo);
++    int16x8_t stats4 = vmulq_s16(diff_lo, mask4_lo);
++    stats0 = vmlaq_s16(stats0, diff_hi, mask0_hi);
++    stats1 = vmlaq_s16(stats1, diff_hi, mask1_hi);
++    stats2 = vmlaq_s16(stats2, diff_hi, mask2_hi);
++    stats3 = vmlaq_s16(stats3, diff_hi, mask3_hi);
++    stats4 = vmlaq_s16(stats4, diff_hi, mask4_hi);
++
++    stats[0] = vpadalq_s16(stats[0], stats0);
++    stats[1] = vpadalq_s16(stats[1], stats1);
++    stats[2] = vpadalq_s16(stats[2], stats2);
++    stats[3] = vpadalq_s16(stats[3], stats3);
++    stats[4] = vpadalq_s16(stats[4], stats4);
++}
++
++/*
++ * Reduce and store Edge Offset statistics (count and stats).
++ */
++static inline void reduce_eo_stats(int32x4_t *vstats, int16x8_t *vcount,
++                                   int32_t *stats, int32_t *count)
++{
++    // s_eoTable maps edge types to memory in order: {2, 0, 1, 3, 4}.
++    int16x8_t c01 = vpaddq_s16(vcount[2], vcount[0]);
++    int16x8_t c23 = vpaddq_s16(vcount[1], vcount[3]);
++    int16x8_t c0123 = vpaddq_s16(c01, c23);
++
++    // Subtract from current count, as we calculate the negation.
++    vst1q_s32(count, vsubq_s32(vld1q_s32(count), vpaddlq_s16(c0123)));
++    count[4] -= vaddvq_s16(vcount[4]);
++
++    int32x4_t s01 = vpaddq_s32(vstats[2], vstats[0]);
++    int32x4_t s23 = vpaddq_s32(vstats[1], vstats[3]);
++    int32x4_t s0123 = vpaddq_s32(s01, s23);
++
++    // Subtract from current stats, as we calculate the negation.
++    vst1q_s32(stats, vsubq_s32(vld1q_s32(stats), s0123));
++    stats[4] -= vaddvq_s32(vstats[4]);
++}
++
++namespace X265_NS {
++void saoCuStatsBO_neon(const int16_t *diff, const pixel *rec, intptr_t stride,
++                       int endX, int endY, int32_t *stats, int32_t *count)
++{
++#if HIGH_BIT_DEPTH
++    const int n_elem = 4;
++    const int elem_width = 16;
++#else
++    const int n_elem = 8;
++    const int elem_width = 8;
++#endif
++
++    // Additional temporary buffer for accumulation.
++    int32_t stats_tmp[32] = { 0 };
++    int32_t count_tmp[32] = { 0 };
++
++    // Byte-addressable pointers to buffers, to optimise address calculation.
++    uint8_t *stats_b[2] = {
++        reinterpret_cast<uint8_t *>(stats),
++        reinterpret_cast<uint8_t *>(stats_tmp),
++    };
++    uint8_t *count_b[2] = {
++        reinterpret_cast<uint8_t *>(count),
++        reinterpret_cast<uint8_t *>(count_tmp),
++    };
++
++    // Combine shift for index calculation with shift for address calculation.
++    const int right_shift = X265_DEPTH - X265_NS::SAO::SAO_BO_BITS;
++    const int left_shift = 2;
++    const int shift = right_shift - left_shift;
++    // Mask out bits 7, 1 & 0 to account for combination of shifts.
++    const int mask = 0x7c;
++
++    // Compute statistics into temporary buffers.
++    for (int y = 0; y < endY; y++)
++    {
++        int x = 0;
++        for (; x + n_elem < endX; x += n_elem)
++        {
++            uint64_t class_idx_64 =
++                *reinterpret_cast<const uint64_t *>(rec + x) >> shift;
++
++            for (int i = 0; i < n_elem; ++i)
++            {
++                const int idx = i & 1;
++                const int off  = (class_idx_64 >> (i * elem_width)) & mask;
++                *reinterpret_cast<uint32_t*>(stats_b[idx] + off) += diff[x + i];
++                *reinterpret_cast<uint32_t*>(count_b[idx] + off) += 1;
++            }
++        }
++
++        if (x < endX)
++        {
++            uint64_t class_idx_64 =
++                *reinterpret_cast<const uint64_t *>(rec + x) >> shift;
++
++            for (int i = 0; (i + x) < endX; ++i)
++            {
++                const int idx = i & 1;
++                const int off  = (class_idx_64 >> (i * elem_width)) & mask;
++                *reinterpret_cast<uint32_t*>(stats_b[idx] + off) += diff[x + i];
++                *reinterpret_cast<uint32_t*>(count_b[idx] + off) += 1;
++            }
++        }
++
++        diff += MAX_CU_SIZE;
++        rec += stride;
++    }
++
++    // Reduce temporary buffers to destination using Neon.
++    for (int i = 0; i < 32; i += 4)
++    {
++        int32x4_t s0 = vld1q_s32(stats_tmp + i);
++        int32x4_t s1 = vld1q_s32(stats + i);
++        vst1q_s32(stats + i, vaddq_s32(s0, s1));
++
++        int32x4_t c0 = vld1q_s32(count_tmp + i);
++        int32x4_t c1 = vld1q_s32(count + i);
++        vst1q_s32(count + i, vaddq_s32(c0, c1));
++    }
++}
++
++void saoCuStatsE0_neon(const int16_t *diff, const pixel *rec, intptr_t stride,
++                       int endX, int endY, int32_t *stats, int32_t *count)
++{
++    // Separate buffers for each edge type, so that we can vectorise.
++    int16x8_t tmp_count[5] = { vdupq_n_s16(0), vdupq_n_s16(0), vdupq_n_s16(0),
++                               vdupq_n_s16(0), vdupq_n_s16(0) };
++    int32x4_t tmp_stats[5] = { vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0),
++                               vdupq_n_s32(0), vdupq_n_s32(0) };
++
++    for (int y = 0; y < endY; y++)
++    {
++        // Calculate negated sign_left(x) directly, to save negation when
++        // reusing sign_right(x) as sign_left(x + 1).
++        int8x16_t neg_sign_left = vdupq_n_s8(x265_signOf(rec[-1] - rec[0]));
++        for (int x = 0; x < endX; x += 16)
++        {
++            int8x16_t sign_right = signOf_neon(rec + x, rec + x + 1);
++
++            // neg_sign_left(x) = sign_right(x + 1), reusing one from previous
++            // iteration.
++            neg_sign_left = vextq_s8(neg_sign_left, sign_right, 15);
++
++            // Subtract instead of add, as sign_left is negated.
++            int8x16_t edge_type = vsubq_s8(sign_right, neg_sign_left);
++
++            // For reuse in the next iteration.
++            neg_sign_left = sign_right;
++
++            edge_type = mask_inactive_elems(endX - x, edge_type);
++            compute_eo_stats(edge_type, diff + x, tmp_count, tmp_stats);
++        }
++
++        diff += MAX_CU_SIZE;
++        rec += stride;
++    }
++
++    reduce_eo_stats(tmp_stats, tmp_count, stats, count);
++}
++
++void saoCuStatsE1_neon(const int16_t *diff, const pixel *rec, intptr_t stride,
++                       int8_t *upBuff1, int endX, int endY, int32_t *stats,
++                       int32_t *count)
++{
++    // Separate buffers for each edge type, so that we can vectorise.
++    int16x8_t tmp_count[5] = { vdupq_n_s16(0), vdupq_n_s16(0), vdupq_n_s16(0),
++                               vdupq_n_s16(0), vdupq_n_s16(0) };
++    int32x4_t tmp_stats[5] = { vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0),
++                               vdupq_n_s32(0), vdupq_n_s32(0) };
++
++    // Negate upBuff1 (sign_up), so we can subtract and save repeated negations.
++    for (int x = 0; x < endX; x += 16)
++    {
++        vst1q_s8(upBuff1 + x, vnegq_s8(vld1q_s8(upBuff1 + x)));
++    }
++
++    for (int y = 0; y < endY; y++)
++    {
++        for (int x = 0; x < endX; x += 16)
++        {
++            int8x16_t sign_up = vld1q_s8(upBuff1 + x);
++            int8x16_t sign_down = signOf_neon(rec + x, rec + x + stride);
++
++            // Subtract instead of add, as sign_up is negated.
++            int8x16_t edge_type = vsubq_s8(sign_down, sign_up);
++
++            // For reuse in the next iteration.
++            vst1q_s8(upBuff1 + x, sign_down);
++
++            edge_type = mask_inactive_elems(endX - x, edge_type);
++            compute_eo_stats(edge_type, diff + x, tmp_count, tmp_stats);
++        }
++
++        diff += MAX_CU_SIZE;
++        rec += stride;
++    }
++
++    reduce_eo_stats(tmp_stats, tmp_count, stats, count);
++}
++
++void saoCuStatsE2_neon(const int16_t *diff, const pixel *rec, intptr_t stride,
++                       int8_t *upBuff1, int8_t *upBufft, int endX, int endY,
++                       int32_t *stats, int32_t *count)
++{
++    // Separate buffers for each edge type, so that we can vectorise.
++    int16x8_t tmp_count[5] = { vdupq_n_s16(0), vdupq_n_s16(0), vdupq_n_s16(0),
++                               vdupq_n_s16(0), vdupq_n_s16(0) };
++    int32x4_t tmp_stats[5] = { vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0),
++                               vdupq_n_s32(0), vdupq_n_s32(0) };
++
++    // Negate upBuff1 (sign_up) so we can subtract and save repeated negations.
++    for (int x = 0; x < endX; x += 16)
++    {
++        vst1q_s8(upBuff1 + x, vnegq_s8(vld1q_s8(upBuff1 + x)));
++    }
++
++    for (int y = 0; y < endY; y++)
++    {
++        upBufft[0] = x265_signOf(rec[-1] - rec[stride]);
++        for (int x = 0; x < endX; x += 16)
++        {
++            int8x16_t sign_up = vld1q_s8(upBuff1 + x);
++            int8x16_t sign_down = signOf_neon(rec + x, rec + x + stride + 1);
++
++            // Subtract instead of add, as sign_up is negated.
++            int8x16_t edge_type = vsubq_s8(sign_down, sign_up);
++
++            // For reuse in the next iteration.
++            vst1q_s8(upBufft + x + 1, sign_down);
++
++            edge_type = mask_inactive_elems(endX - x, edge_type);
++            compute_eo_stats(edge_type, diff + x, tmp_count, tmp_stats);
++        }
++
++        std::swap(upBuff1, upBufft);
++
++        rec += stride;
++        diff += MAX_CU_SIZE;
++    }
++
++    reduce_eo_stats(tmp_stats, tmp_count, stats, count);
++}
++
++void saoCuStatsE3_neon(const int16_t *diff, const pixel *rec, intptr_t stride,
++                       int8_t *upBuff1, int endX, int endY, int32_t *stats,
++                       int32_t *count)
++{
++    // Separate buffers for each edge type, so that we can vectorise.
++    int16x8_t tmp_count[5] = { vdupq_n_s16(0), vdupq_n_s16(0), vdupq_n_s16(0),
++                               vdupq_n_s16(0), vdupq_n_s16(0) };
++    int32x4_t tmp_stats[5] = { vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0),
++                               vdupq_n_s32(0), vdupq_n_s32(0) };
++
++    // Negate upBuff1 (sign_up) so we can subtract and save repeated negations.
++    for (int x = 0; x < endX; x += 16)
++    {
++        vst1q_s8(upBuff1 + x, vnegq_s8(vld1q_s8(upBuff1 + x)));
++    }
++
++    for (int y = 0; y < endY; y++)
++    {
++        for (int x = 0; x < endX; x += 16)
++        {
++            int8x16_t sign_up = vld1q_s8(upBuff1 + x);
++            int8x16_t sign_down = signOf_neon(rec + x, rec + x + stride - 1);
++
++            // subtraction instead of addition, as sign_up is negated.
++            int8x16_t edge_type = vsubq_s8(sign_down, sign_up);
++
++            // For reuse in the next iteration.
++            vst1q_s8(upBuff1 + x - 1, sign_down);
++
++            edge_type = mask_inactive_elems(endX - x, edge_type);
++            compute_eo_stats(edge_type, diff + x, tmp_count, tmp_stats);
++        }
++
++        upBuff1[endX - 1] = x265_signOf(rec[endX] - rec[endX - 1 + stride]);
++
++        rec += stride;
++        diff += MAX_CU_SIZE;
++    }
++
++    reduce_eo_stats(tmp_stats, tmp_count, stats, count);
++}
++
++void setupSaoPrimitives_neon(EncoderPrimitives &p)
++{
++    p.saoCuStatsBO = saoCuStatsBO_neon;
++    p.saoCuStatsE0 = saoCuStatsE0_neon;
++    p.saoCuStatsE1 = saoCuStatsE1_neon;
++    p.saoCuStatsE2 = saoCuStatsE2_neon;
++    p.saoCuStatsE3 = saoCuStatsE3_neon;
++}
++} // namespace X265_NS
+diff --git a/source/common/aarch64/sao-prim.h b/source/common/aarch64/sao-prim.h
+new file mode 100644
+index 000000000..dc75c3026
+--- /dev/null
++++ b/source/common/aarch64/sao-prim.h
+@@ -0,0 +1,65 @@
++/*****************************************************************************
++ * Copyright (C) 2024 MulticoreWare, Inc
++ *
++ * Authors: Hari Limaye <hari.limaye@arm.com>
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111, USA.
++ *
++ * This program is also available under a commercial proprietary license.
++ * For more information, contact us at license @ x265.com.
++ *****************************************************************************/
++
++#ifndef X265_COMMON_AARCH64_SAO_PRIM_H
++#define X265_COMMON_AARCH64_SAO_PRIM_H
++
++#include "primitives.h"
++#include <arm_neon.h>
++
++static inline int8x16_t signOf_neon(const pixel *a, const pixel *b)
++{
++#if HIGH_BIT_DEPTH
++    uint16x8_t s0_lo = vld1q_u16(a);
++    uint16x8_t s0_hi = vld1q_u16(a + 8);
++    uint16x8_t s1_lo = vld1q_u16(b);
++    uint16x8_t s1_hi = vld1q_u16(b + 8);
++
++    // signOf(a - b) = -(a > b ? -1 : 0) | (a < b ? -1 : 0)
++    int16x8_t cmp0_lo = vreinterpretq_s16_u16(vcgtq_u16(s0_lo, s1_lo));
++    int16x8_t cmp0_hi = vreinterpretq_s16_u16(vcgtq_u16(s0_hi, s1_hi));
++    int16x8_t cmp1_lo = vreinterpretq_s16_u16(vcgtq_u16(s1_lo, s0_lo));
++    int16x8_t cmp1_hi = vreinterpretq_s16_u16(vcgtq_u16(s1_hi, s0_hi));
++
++    int8x16_t cmp0 = vcombine_s8(vmovn_s16(cmp0_lo), vmovn_s16(cmp0_hi));
++    int8x16_t cmp1 = vcombine_s8(vmovn_s16(cmp1_lo), vmovn_s16(cmp1_hi));
++#else // HIGH_BIT_DEPTH
++    uint8x16_t s0 = vld1q_u8(a);
++    uint8x16_t s1 = vld1q_u8(b);
++
++    // signOf(a - b) = -(a > b ? -1 : 0) | (a < b ? -1 : 0)
++    int8x16_t cmp0 = vreinterpretq_s8_u8(vcgtq_u8(s0, s1));
++    int8x16_t cmp1 = vreinterpretq_s8_u8(vcgtq_u8(s1, s0));
++#endif // HIGH_BIT_DEPTH
++    return vorrq_s8(vnegq_s8(cmp0), cmp1);
++}
++
++namespace X265_NS {
++void setupSaoPrimitives_neon(EncoderPrimitives &p);
++
++#if defined(HAVE_SVE) && HAVE_SVE_BRIDGE
++void setupSaoPrimitives_sve(EncoderPrimitives &p);
++#endif
++}
++
++#endif // X265_COMMON_AARCH64_SAO_PRIM_H
+diff --git a/source/common/aarch64/ssd-a-sve2.S b/source/common/aarch64/ssd-a-sve2.S
+index de2603850..8077bd93c 100644
+--- a/source/common/aarch64/ssd-a-sve2.S
++++ b/source/common/aarch64/ssd-a-sve2.S
+@@ -43,7 +43,7 @@ function PFX(pixel_sse_pp_32x32_sve2)
+     mov             w12, #8
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_sse_pp_32_sve2:
++.Loop_sse_pp_32_sve2:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b,v17.16b}, [x0], x1
+@@ -61,7 +61,7 @@ function PFX(pixel_sse_pp_32x32_sve2)
+     smlal           v0.4s, v5.4h, v5.4h
+     smlal2          v1.4s, v5.8h, v5.8h
+ .endr
+-    cbnz            w12, .loop_sse_pp_32_sve2
++    cbnz            w12, .Loop_sse_pp_32_sve2
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ .vl_gt_16_pixel_sse_pp_32x32:
+@@ -182,7 +182,7 @@ function PFX(pixel_sse_pp_64x64_sve2)
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+ 
+-.loop_sse_pp_64_sve2:
++.Loop_sse_pp_64_sve2:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b-v19.16b}, [x0], x1
+@@ -214,7 +214,7 @@ function PFX(pixel_sse_pp_64x64_sve2)
+     smlal           v0.4s, v5.4h, v5.4h
+     smlal2          v1.4s, v5.8h, v5.8h
+ .endr
+-    cbnz            w12, .loop_sse_pp_64_sve2
++    cbnz            w12, .Loop_sse_pp_64_sve2
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ .vl_gt_16_pixel_sse_pp_64x64:
+@@ -788,7 +788,7 @@ function PFX(pixel_ssd_s_16x16_sve2)
+     mov             w12, #4
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_ssd_s_16_sve2:
++.Loop_ssd_s_16_sve2:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v4.16b,v5.16b}, [x0], x1
+@@ -802,7 +802,7 @@ function PFX(pixel_ssd_s_16x16_sve2)
+     smlal           v0.4s, v7.4h, v7.4h
+     smlal2          v1.4s, v7.8h, v7.8h
+ .endr
+-    cbnz            w12, .loop_ssd_s_16_sve2
++    cbnz            w12, .Loop_ssd_s_16_sve2
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ .vl_gt_16_pixel_ssd_s_16x16:
+@@ -830,7 +830,7 @@ function PFX(pixel_ssd_s_32x32_sve2)
+     mov             w12, #8
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_ssd_s_32:
++.Loop_ssd_s_32:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v4.16b-v7.16b}, [x0], x1
+@@ -843,7 +843,7 @@ function PFX(pixel_ssd_s_32x32_sve2)
+     smlal           v0.4s, v7.4h, v7.4h
+     smlal2          v1.4s, v7.8h, v7.8h
+ .endr
+-    cbnz            w12, .loop_ssd_s_32
++    cbnz            w12, .Loop_ssd_s_32
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ .vl_gt_16_pixel_ssd_s_32x32:
+diff --git a/source/common/aarch64/ssd-a.S b/source/common/aarch64/ssd-a.S
+index 7c778b4fe..f4b79304a 100644
+--- a/source/common/aarch64/ssd-a.S
++++ b/source/common/aarch64/ssd-a.S
+@@ -157,7 +157,7 @@ function PFX(pixel_sse_pp_32x32_neon)
+     mov             w12, #8
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_sse_pp_32:
++.Loop_sse_pp_32:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b,v17.16b}, [x0], x1
+@@ -175,7 +175,7 @@ function PFX(pixel_sse_pp_32x32_neon)
+     smlal           v0.4s, v5.4h, v5.4h
+     smlal2          v1.4s, v5.8h, v5.8h
+ .endr
+-    cbnz            w12, .loop_sse_pp_32
++    cbnz            w12, .Loop_sse_pp_32
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ endfunc
+@@ -184,7 +184,7 @@ function PFX(pixel_sse_pp_32x64_neon)
+     mov             w12, #16
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_sse_pp_32x64:
++.Loop_sse_pp_32x64:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b,v17.16b}, [x0], x1
+@@ -202,7 +202,7 @@ function PFX(pixel_sse_pp_32x64_neon)
+     smlal           v0.4s, v5.4h, v5.4h
+     smlal2          v1.4s, v5.8h, v5.8h
+ .endr
+-    cbnz            w12, .loop_sse_pp_32x64
++    cbnz            w12, .Loop_sse_pp_32x64
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ endfunc
+@@ -212,7 +212,7 @@ function PFX(pixel_sse_pp_64x64_neon)
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+ 
+-.loop_sse_pp_64:
++.Loop_sse_pp_64:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b-v19.16b}, [x0], x1
+@@ -244,7 +244,7 @@ function PFX(pixel_sse_pp_64x64_neon)
+     smlal           v0.4s, v5.4h, v5.4h
+     smlal2          v1.4s, v5.8h, v5.8h
+ .endr
+-    cbnz            w12, .loop_sse_pp_64
++    cbnz            w12, .Loop_sse_pp_64
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ endfunc
+@@ -301,7 +301,7 @@ function PFX(pixel_sse_ss_16x16_neon)
+     mov             w12, #4
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_sse_ss_16:
++.Loop_sse_ss_16:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b, v17.16b}, [x0], x1
+@@ -313,7 +313,7 @@ function PFX(pixel_sse_ss_16x16_neon)
+     smlal           v0.4s, v3.4h, v3.4h
+     smlal2          v1.4s, v3.8h, v3.8h
+ .endr
+-    cbnz            w12, .loop_sse_ss_16
++    cbnz            w12, .Loop_sse_ss_16
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ endfunc
+@@ -325,7 +325,7 @@ function PFX(pixel_sse_ss_32x32_neon)
+     mov             w12, #8
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_sse_ss_32:
++.Loop_sse_ss_32:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v16.16b-v19.16b}, [x0], x1
+@@ -343,7 +343,7 @@ function PFX(pixel_sse_ss_32x32_neon)
+     smlal           v0.4s, v5.4h, v5.4h
+     smlal2          v1.4s, v5.8h, v5.8h
+ .endr
+-    cbnz            w12, .loop_sse_ss_32
++    cbnz            w12, .Loop_sse_ss_32
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ endfunc
+@@ -357,7 +357,7 @@ function PFX(pixel_sse_ss_64x64_neon)
+     mov             w12, #32
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_sse_ss_64:
++.Loop_sse_ss_64:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v16.16b-v19.16b}, [x0], #64
+@@ -389,7 +389,7 @@ function PFX(pixel_sse_ss_64x64_neon)
+     smlal           v0.4s, v5.4h, v5.4h
+     smlal2          v1.4s, v5.8h, v5.8h
+ .endr
+-    cbnz            w12, .loop_sse_ss_64
++    cbnz            w12, .Loop_sse_ss_64
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ endfunc
+@@ -433,7 +433,7 @@ function PFX(pixel_ssd_s_16x16_neon)
+     mov             w12, #4
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_ssd_s_16:
++.Loop_ssd_s_16:
+     sub             w12, w12, #1
+ .rept 2
+     ld1             {v4.16b,v5.16b}, [x0], x1
+@@ -447,7 +447,7 @@ function PFX(pixel_ssd_s_16x16_neon)
+     smlal           v0.4s, v7.4h, v7.4h
+     smlal2          v1.4s, v7.8h, v7.8h
+ .endr
+-    cbnz            w12, .loop_ssd_s_16
++    cbnz            w12, .Loop_ssd_s_16
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ endfunc
+@@ -457,7 +457,7 @@ function PFX(pixel_ssd_s_32x32_neon)
+     mov             w12, #8
+     movi            v0.16b, #0
+     movi            v1.16b, #0
+-.loop_ssd_s_32:
++.Loop_ssd_s_32:
+     sub             w12, w12, #1
+ .rept 4
+     ld1             {v4.16b-v7.16b}, [x0], x1
+@@ -470,7 +470,7 @@ function PFX(pixel_ssd_s_32x32_neon)
+     smlal           v0.4s, v7.4h, v7.4h
+     smlal2          v1.4s, v7.8h, v7.8h
+ .endr
+-    cbnz            w12, .loop_ssd_s_32
++    cbnz            w12, .Loop_ssd_s_32
+     add             v0.4s, v0.4s, v1.4s
+     ret_v0_w0
+ endfunc
+diff --git a/source/common/arm/blockcopy8.S b/source/common/arm/blockcopy8.S
+index 1c868f464..8170160aa 100644
+--- a/source/common/arm/blockcopy8.S
++++ b/source/common/arm/blockcopy8.S
+@@ -795,7 +795,7 @@ function x265_count_nonzero_32_neon
+     vmov            q2, q12
+     vmov            q3, q14
+ 
+-.loop:    
++.Loop:
+     vldm            r0!, {q8-q15}
+     subs            r1, #1
+ 
+@@ -817,7 +817,7 @@ function x265_count_nonzero_32_neon
+     vadd.s8         q1, q10
+     vadd.s8         q2, q12
+     vadd.s8         q3, q14
+-    bgt            .loop
++    bgt            .Loop
+ 
+     // sum
+     vadd.s8         q0, q1
+diff --git a/source/common/arm/dct-a.S b/source/common/arm/dct-a.S
+index 42b193bf8..5be8847e9 100644
+--- a/source/common/arm/dct-a.S
++++ b/source/common/arm/dct-a.S
+@@ -422,7 +422,7 @@ function x265_dct_16x16_neon
+     mov lr, #4*16*2
+ 
+     // DCT-1D
+-.loop1:
++.Loop1:
+     // Row[0-3]
+     vld1.16 {q8-q9}, [r0, :64], r2      // q8  = [07 06 05 04 03 02 01 00], q9  = [0F 0E 0D 0C 0B 0A 09 08]
+     vld1.16 {q10-q11}, [r0, :64], r2    // q10 = [17 16 15 14 13 12 11 10], q11 = [1F 1E 1D 1C 1B 1A 19 18]
+@@ -628,7 +628,7 @@ function x265_dct_16x16_neon
+     // loop into next process group
+     sub r3, #3*4*16*2
+     subs r12, #1
+-    bgt .loop1
++    bgt .Loop1
+ 
+ 
+     // DCT-2D
+@@ -637,7 +637,7 @@ function x265_dct_16x16_neon
+     mov r3, #16*2*2
+     mov r12, #16/4                      // Process 4 rows every loop
+ 
+-.loop2:
++.Loop2:
+     vldm r2, {q8-q15}
+ 
+     // d16 = [30 20 10 00]
+@@ -887,7 +887,7 @@ function x265_dct_16x16_neon
+ 
+     sub r1, #(17*16-4)*2
+     subs r12, #1
+-    bgt .loop2
++    bgt .Loop2
+ 
+     add sp, #16*16*2
+     vpop {q4-q7}
+diff --git a/source/common/arm/ipfilter8.S b/source/common/arm/ipfilter8.S
+index 8b7f5b3ca..b1ec6cc8b 100644
+--- a/source/common/arm/ipfilter8.S
++++ b/source/common/arm/ipfilter8.S
+@@ -372,7 +372,7 @@ function x265_filterPixelToShort_32x16_neon
+     vmov.u16    q1, #8192
+     vneg.s16    q1, q1
+     mov         r12, #8
+-.loop_filterP2S_32x16:
++.Loop_filterP2S_32x16:
+     subs        r12, #1
+ .rept 2
+     vld1.u8     {q9-q10}, [r0], r1
+@@ -391,7 +391,7 @@ function x265_filterPixelToShort_32x16_neon
+     vmla.s16    q3, q10, q0
+     vst1.16     {q2-q3}, [r2], r3
+ .endr
+-    bgt         .loop_filterP2S_32x16
++    bgt         .Loop_filterP2S_32x16
+     bx          lr
+ endfunc
+ 
+@@ -402,7 +402,7 @@ function x265_filterPixelToShort_32x24_neon
+     vmov.u16    q1, #8192
+     vneg.s16    q1, q1
+     mov         r12, #12
+-.loop_filterP2S_32x24:
++.Loop_filterP2S_32x24:
+     subs        r12, #1
+ .rept 2
+     vld1.u8     {q9-q10}, [r0], r1
+@@ -421,7 +421,7 @@ function x265_filterPixelToShort_32x24_neon
+     vmla.s16    q3, q10, q0
+     vst1.16     {q2-q3}, [r2], r3
+ .endr
+-    bgt         .loop_filterP2S_32x24
++    bgt         .Loop_filterP2S_32x24
+     bx          lr
+ endfunc
+ 
+@@ -432,7 +432,7 @@ function x265_filterPixelToShort_32x32_neon
+     vmov.u16    q1, #8192
+     vneg.s16    q1, q1
+     mov         r12, #16
+-.loop_filterP2S_32x32:
++.Loop_filterP2S_32x32:
+     subs        r12, #1
+ .rept 2
+     vld1.u8     {q9-q10}, [r0], r1
+@@ -451,7 +451,7 @@ function x265_filterPixelToShort_32x32_neon
+     vmla.s16    q3, q10, q0
+     vst1.16     {q2-q3}, [r2], r3
+ .endr
+-    bgt         .loop_filterP2S_32x32
++    bgt         .Loop_filterP2S_32x32
+     bx          lr
+ endfunc
+ 
+@@ -462,7 +462,7 @@ function x265_filterPixelToShort_32x64_neon
+     vmov.u16    q1, #8192
+     vneg.s16    q1, q1
+     mov         r12, #32
+-.loop_filterP2S_32x64:
++.Loop_filterP2S_32x64:
+     subs        r12, #1
+ .rept 2
+     vld1.u8     {q9-q10}, [r0], r1
+@@ -481,7 +481,7 @@ function x265_filterPixelToShort_32x64_neon
+     vmla.s16    q3, q10, q0
+     vst1.16     {q2-q3}, [r2], r3
+ .endr
+-    bgt         .loop_filterP2S_32x64
++    bgt         .Loop_filterP2S_32x64
+     bx          lr
+ endfunc
+ 
+@@ -493,7 +493,7 @@ function x265_filterPixelToShort_64x16_neon
+     vmov.u16    q1, #8192
+     vneg.s16    q1, q1
+     mov         r12, #8
+-.loop_filterP2S_64x16:
++.Loop_filterP2S_64x16:
+     subs        r12, #1
+ .rept 2
+     vld1.u8     {q9-q10}, [r0]!
+@@ -528,7 +528,7 @@ function x265_filterPixelToShort_64x16_neon
+     vmla.s16    q3, q10, q0
+     vst1.16     {q2-q3}, [r2], r3
+ .endr
+-    bgt         .loop_filterP2S_64x16
++    bgt         .Loop_filterP2S_64x16
+     bx          lr
+ endfunc
+ 
+@@ -540,7 +540,7 @@ function x265_filterPixelToShort_64x32_neon
+     vmov.u16    q1, #8192
+     vneg.s16    q1, q1
+     mov         r12, #16
+-.loop_filterP2S_64x32:
++.Loop_filterP2S_64x32:
+     subs        r12, #1
+ .rept 2
+     vld1.u8     {q9-q10}, [r0]!
+@@ -575,7 +575,7 @@ function x265_filterPixelToShort_64x32_neon
+     vmla.s16    q3, q10, q0
+     vst1.16     {q2-q3}, [r2], r3
+ .endr
+-    bgt         .loop_filterP2S_64x32
++    bgt         .Loop_filterP2S_64x32
+     bx          lr
+ endfunc
+ 
+@@ -587,7 +587,7 @@ function x265_filterPixelToShort_64x48_neon
+     vmov.u16    q1, #8192
+     vneg.s16    q1, q1
+     mov         r12, #24
+-.loop_filterP2S_64x48:
++.Loop_filterP2S_64x48:
+     subs        r12, #1
+ .rept 2
+     vld1.u8     {q9-q10}, [r0]!
+@@ -622,7 +622,7 @@ function x265_filterPixelToShort_64x48_neon
+     vmla.s16    q3, q10, q0
+     vst1.16     {q2-q3}, [r2], r3
+ .endr
+-    bgt         .loop_filterP2S_64x48
++    bgt         .Loop_filterP2S_64x48
+     bx          lr
+ endfunc
+ 
+@@ -634,7 +634,7 @@ function x265_filterPixelToShort_64x64_neon
+     vmov.u16    q1, #8192
+     vneg.s16    q1, q1
+     mov         r12, #32
+-.loop_filterP2S_64x64:
++.Loop_filterP2S_64x64:
+     subs        r12, #1
+ .rept 2
+     vld1.u8     {q9-q10}, [r0]!
+@@ -669,7 +669,7 @@ function x265_filterPixelToShort_64x64_neon
+     vmla.s16    q3, q10, q0
+     vst1.16     {q2-q3}, [r2], r3
+ .endr
+-    bgt         .loop_filterP2S_64x64
++    bgt         .Loop_filterP2S_64x64
+     bx          lr
+ endfunc
+ 
+@@ -681,7 +681,7 @@ function x265_filterPixelToShort_48x64_neon
+     vmov.u16    q1, #8192
+     vneg.s16    q1, q1
+     mov         r12, #32
+-.loop_filterP2S_48x64:
++.Loop_filterP2S_48x64:
+     subs        r12, #1
+ .rept 2
+     vld1.u8     {q9-q10}, [r0]!
+@@ -709,7 +709,7 @@ function x265_filterPixelToShort_48x64_neon
+     vmla.s16    q3, q9, q0
+     vst1.16     {q2-q3}, [r2], r3
+ .endr
+-    bgt         .loop_filterP2S_48x64
++    bgt         .Loop_filterP2S_48x64
+     bx          lr
+ endfunc
+ 
+@@ -756,7 +756,7 @@ function x265_interp_8tap_vert_pp_4x\h\()_neon
+     vmovl.u8    q2, d4
+     vmovl.u8    q3, d6
+ 
+-.loop_4x\h:
++.Loop_4x\h:
+     // TODO: read extra 1 row for speed optimize, may made crash on OS X platform!
+     vld1.u32    {d16[0]}, [r0], r1
+     vld1.u32    {d16[1]}, [r0], r1
+@@ -795,7 +795,7 @@ function x265_interp_8tap_vert_pp_4x\h\()_neon
+     vst1.u32    {d18[1]}, [r2], r3
+ 
+     subs        r12, #2
+-    bne        .loop_4x4
++    bne        .Loop_4x4
+ 
+     pop         {pc}
+     .ltorg
+@@ -945,13 +945,13 @@ LUMA_VPP_4xN 16
+ 
+ .macro FILTER_VPP a b filterv
+ 
+-.loop_\filterv\()_\a\()x\b:
++.Loop_\filterv\()_\a\()x\b:
+ 
+     mov             r7, r2
+     mov             r6, r0
+     eor             r8, r8
+ 
+-.loop_w8_\filterv\()_\a\()x\b:
++.Loop_w8_\filterv\()_\a\()x\b:
+ 
+     add             r6, r0, r8
+ 
+@@ -988,12 +988,12 @@ LUMA_VPP_4xN 16
+ 
+     add             r8, #8
+     cmp             r8, #\a
+-    blt             .loop_w8_\filterv\()_\a\()x\b
++    blt             .Loop_w8_\filterv\()_\a\()x\b
+ 
+     add             r0, r1
+     add             r2, r3
+     subs            r4, #1
+-    bne             .loop_\filterv\()_\a\()x\b 
++    bne             .Loop_\filterv\()_\a\()x\b
+ 
+ .endm 
+ 
+@@ -1063,7 +1063,7 @@ function x265_interp_8tap_vert_pp_12x16_neon
+     sub             r0, r4
+ 
+     mov             r4, #16
+-.loop_vpp_12x16:
++.Loop_vpp_12x16:
+ 
+     mov             r6, r0
+     mov             r7, r2
+@@ -1173,7 +1173,7 @@ function x265_interp_8tap_vert_pp_12x16_neon
+     add             r0, r1
+     add             r2, r3
+     subs            r4, #1
+-    bne             .loop_vpp_12x16
++    bne             .Loop_vpp_12x16
+ 
+     pop             {r4, r5, r6, r7}
+     bx              lr
+@@ -1194,7 +1194,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_neon
+     add             r12, #2048
+     vdup.32         q8, r12
+     mov             r4, #\h
+-.loop_vsp_4x\h:
++.Loop_vsp_4x\h:
+     movrel          r12, g_lumaFilter
+     add             r12, r5
+     mov             r6, r0
+@@ -1266,7 +1266,7 @@ function x265_interp_8tap_vert_sp_4x\h\()_neon
+ 
+     add             r0, r1
+     subs            r4, #1
+-    bne             .loop_vsp_4x\h
++    bne             .Loop_vsp_4x\h
+     pop             {r4, r5, r6}
+     bx              lr
+     .ltorg
+@@ -1369,13 +1369,13 @@ LUMA_VSP_4xN 16
+ .macro FILTER_VSP a b filterv
+ 
+     vpush           { q4 - q7}
+-.loop_\filterv\()_\a\()x\b:
++.Loop_\filterv\()_\a\()x\b:
+ 
+     mov             r7, r2
+     mov             r6, r0
+     eor             r8, r8
+ 
+-.loop_w8_\filterv\()_\a\()x\b:
++.Loop_w8_\filterv\()_\a\()x\b:
+ 
+     add             r6, r0, r8
+ 
+@@ -1417,12 +1417,12 @@ LUMA_VSP_4xN 16
+     mov             r12, #\a
+     lsl             r12, #1
+     cmp             r8, r12
+-    blt             .loop_w8_\filterv\()_\a\()x\b
++    blt             .Loop_w8_\filterv\()_\a\()x\b
+ 
+     add             r0, r1
+     add             r2, r3
+     subs            r4, #1
+-    bne             .loop_\filterv\()_\a\()x\b
++    bne             .Loop_\filterv\()_\a\()x\b
+ 
+     vpop            { q4 - q7}
+ 
+@@ -1498,7 +1498,7 @@ function x265_interp_8tap_vert_sp_12x16_neon
+ 
+     mov             r4, #16
+     vpush           { q4 - q7}
+-.loop1_12x16:
++.Loop1_12x16:
+ 
+     mov             r6, r0
+     mov             r7, r2
+@@ -1612,7 +1612,7 @@ function x265_interp_8tap_vert_sp_12x16_neon
+     add             r0, r1
+     add             r2, r3
+     subs            r4, #1
+-    bne             .loop1_12x16
++    bne             .Loop1_12x16
+     vpop            { q4 - q7}
+     pop             {r4, r5, r6, r7}
+     bx              lr
+@@ -1632,7 +1632,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_neon
+     vdup.32         q8, r4
+     mov             r4, #\h
+ 
+-.loop_vps_4x\h:
++.Loop_vps_4x\h:
+     movrel          r12, g_lumaFilter
+     add             r12, r5
+     mov             r6, r0
+@@ -1702,7 +1702,7 @@ function x265_interp_8tap_vert_ps_4x\h\()_neon
+ 
+     add             r0, r1
+     subs            r4, #1
+-    bne             .loop_vps_4x\h
++    bne             .Loop_vps_4x\h
+ 
+     pop             {r4, r5, r6}
+     bx              lr
+@@ -1717,13 +1717,13 @@ LUMA_VPS_4xN 16
+ 
+ .macro FILTER_VPS a b filterv
+ 
+-.loop_ps_\filterv\()_\a\()x\b:
++.Loop_ps_\filterv\()_\a\()x\b:
+ 
+     mov             r7, r2
+     mov             r6, r0
+     eor             r8, r8
+ 
+-.loop_ps_w8_\filterv\()_\a\()x\b:
++.Loop_ps_w8_\filterv\()_\a\()x\b:
+ 
+     add             r6, r0, r8
+ 
+@@ -1759,12 +1759,12 @@ LUMA_VPS_4xN 16
+ 
+     add             r8, #8
+     cmp             r8, #\a
+-    blt             .loop_ps_w8_\filterv\()_\a\()x\b
++    blt             .Loop_ps_w8_\filterv\()_\a\()x\b
+ 
+     add             r0, r1
+     add             r2, r3
+     subs            r4, #1
+-    bne             .loop_ps_\filterv\()_\a\()x\b 
++    bne             .Loop_ps_\filterv\()_\a\()x\b
+ 
+ .endm 
+ 
+@@ -1836,7 +1836,7 @@ function x265_interp_8tap_vert_ps_12x16_neon
+     sub             r0, r4
+ 
+     mov             r4, #16
+-.loop_vps_12x16:
++.Loop_vps_12x16:
+ 
+     mov             r6, r0
+     mov             r7, r2
+@@ -1942,7 +1942,7 @@ function x265_interp_8tap_vert_ps_12x16_neon
+     add             r0, r1
+     add             r2, r3
+     subs            r4, #1
+-    bne             .loop_vps_12x16
++    bne             .Loop_vps_12x16
+ 
+     pop             {r4, r5, r6, r7}
+     bx              lr
+@@ -2081,13 +2081,13 @@ endfunc
+ 
+     vpush           {q4-q7}
+ 
+-.loop_\filterv\()_\a\()x\b:
++.Loop_\filterv\()_\a\()x\b:
+ 
+     mov             r7, r2
+     mov             r6, r0
+     eor             r8, r8
+ 
+-.loop_w8_\filterv\()_\a\()x\b:
++.Loop_w8_\filterv\()_\a\()x\b:
+ 
+     add             r6, r0, r8
+ 
+@@ -2121,12 +2121,12 @@ endfunc
+ 
+     add             r8, #8
+     cmp             r8, #\a
+-    blt             .loop_w8_\filterv\()_\a\()x\b
++    blt             .Loop_w8_\filterv\()_\a\()x\b
+ 
+     add             r0, r1
+     add             r2, r3
+     subs            r4, #1
+-    bne             .loop_\filterv\()_\a\()x\b 
++    bne             .Loop_\filterv\()_\a\()x\b
+     vpop            {q4-q7}
+ .endm 
+ 
+@@ -2217,13 +2217,13 @@ CHROMA_VPP 48 64
+ 
+     vpush           {q4-q7}
+ 
+-.loop_vps_\filterv\()_\a\()x\b:
++.Loop_vps_\filterv\()_\a\()x\b:
+ 
+     mov             r7, r2
+     mov             r6, r0
+     eor             r8, r8
+ 
+-.loop_vps_w8_\filterv\()_\a\()x\b:
++.Loop_vps_w8_\filterv\()_\a\()x\b:
+ 
+     add             r6, r0, r8
+ 
+@@ -2256,12 +2256,12 @@ CHROMA_VPP 48 64
+ 
+     add             r8, #8
+     cmp             r8, #\a
+-    blt             .loop_vps_w8_\filterv\()_\a\()x\b
++    blt             .Loop_vps_w8_\filterv\()_\a\()x\b
+ 
+     add             r0, r1
+     add             r2, r3
+     subs            r4, #1
+-    bne             .loop_vps_\filterv\()_\a\()x\b 
++    bne             .Loop_vps_\filterv\()_\a\()x\b
+     vpop            {q4-q7}
+ .endm 
+ 
+@@ -2353,13 +2353,13 @@ CHROMA_VPS 48 64
+ 
+     vpush           {q4-q7}
+ 
+-.loop_vsp_\filterv\()_\a\()x\b:
++.Loop_vsp_\filterv\()_\a\()x\b:
+ 
+     mov             r7, r2
+     mov             r6, r0
+     eor             r8, r8
+ 
+-.loop_vsp_w8_\filterv\()_\a\()x\b:
++.Loop_vsp_w8_\filterv\()_\a\()x\b:
+ 
+     add             r6, r0, r8
+ 
+@@ -2392,12 +2392,12 @@ CHROMA_VPS 48 64
+     mov             r12, #\a
+     lsl             r12, #1
+     cmp             r8, r12
+-    blt             .loop_vsp_w8_\filterv\()_\a\()x\b
++    blt             .Loop_vsp_w8_\filterv\()_\a\()x\b
+ 
+     add             r0, r1
+     add             r2, r3
+     subs            r4, #1
+-    bne             .loop_vsp_\filterv\()_\a\()x\b 
++    bne             .Loop_vsp_\filterv\()_\a\()x\b
+     vpop            {q4-q7}
+ .endm 
+ 
+diff --git a/source/common/arm/mc-a.S b/source/common/arm/mc-a.S
+index b10e9e816..839d192cd 100644
+--- a/source/common/arm/mc-a.S
++++ b/source/common/arm/mc-a.S
+@@ -554,7 +554,7 @@ function x265_cpy2Dto1D_shr_16x16_neon
+     vsri.s16        q1, #1
+     vneg.s16        q0, q0
+     mov             r3, #4
+-.loop_cpy2Dto1D_shr_16:
++.Loop_cpy2Dto1D_shr_16:
+     subs            r3, #1
+ .rept 4
+     vld1.s16        {q2-q3}, [r1], r2
+@@ -564,7 +564,7 @@ function x265_cpy2Dto1D_shr_16x16_neon
+     vshl.s16        q3, q0
+     vst1.16         {q2-q3}, [r0]!
+ .endr
+-    bgt             .loop_cpy2Dto1D_shr_16
++    bgt             .Loop_cpy2Dto1D_shr_16
+     bx              lr
+ endfunc
+ 
+@@ -577,7 +577,7 @@ function x265_cpy2Dto1D_shr_32x32_neon
+     vsri.s16        q1, #1
+     vneg.s16        q0, q0
+     mov             r3, 16
+-.loop_cpy2Dto1D_shr_32:
++.Loop_cpy2Dto1D_shr_32:
+     subs            r3, #1
+ .rept 2
+     vld1.s16        {q2-q3}, [r1]!
+@@ -593,7 +593,7 @@ function x265_cpy2Dto1D_shr_32x32_neon
+     vst1.16         {q2-q3}, [r0]!
+     vst1.16         {q8-q9}, [r0]!
+ .endr
+-    bgt             .loop_cpy2Dto1D_shr_32
++    bgt             .Loop_cpy2Dto1D_shr_32
+     bx              lr
+ endfunc
+ 
+diff --git a/source/common/arm/pixel-util.S b/source/common/arm/pixel-util.S
+index c26b17acc..67719c8e5 100644
+--- a/source/common/arm/pixel-util.S
++++ b/source/common/arm/pixel-util.S
+@@ -848,36 +848,36 @@ function x265_pixel_planecopy_cp_neon
+     vdup.8          q2, r12
+     sub             r5, #1
+ 
+-.loop_h:
++.Loop_h:
+     mov             r6, r0
+     mov             r12, r2
+     eor             r7, r7
+-.loop_w:
++.Loop_w:
+     vld1.u8         {q0}, [r6]!
+     vshl.u8         q0, q0, q2
+     vst1.u8         {q0}, [r12]!
+ 
+     add             r7, #16
+     cmp             r7, r4
+-    blt             .loop_w
++    blt             .Loop_w
+ 
+     add             r0, r1
+     add             r2, r3
+ 
+     subs             r5, #1
+-    bgt             .loop_h
++    bgt             .Loop_h
+ 
+ // handle last row
+     mov             r5, r4
+     lsr             r5, #3
+ 
+-.loopW8:
++.LoopW8:
+     vld1.u8         d0, [r0]!
+     vshl.u8         d0, d0, d4
+     vst1.u8         d0, [r2]!
+     subs            r4, r4, #8
+     subs            r5, #1
+-    bgt             .loopW8
++    bgt             .LoopW8
+ 
+     mov             r5,#8
+     sub             r5, r4
+@@ -1970,7 +1970,7 @@ function x265_quant_neon
+     eor             r5, r5
+     veor.s32        q12, q12
+ 
+-.loop_quant:
++.Loop_quant:
+ 
+     vld1.s16        d16, [r0]!
+     vmovl.s16       q9, d16                // q9= coef[blockpos]
+@@ -1999,7 +1999,7 @@ function x265_quant_neon
+     vst1.s16        d16, [r3]!
+ 
+     subs            r4, #1
+-    bne             .loop_quant
++    bne             .Loop_quant
+ 
+     vadd.u32        d8, d9
+     vpadd.u32       d8, d8
+@@ -2023,7 +2023,7 @@ function x265_nquant_neon
+     eor             r4, r4
+     veor.s32        q12, q12
+ 
+-.loop_nquant:
++.Loop_nquant:
+ 
+     vld1.s16        d16, [r0]!
+     vmovl.s16       q9, d16                // q9= coef[blockpos]
+@@ -2049,7 +2049,7 @@ function x265_nquant_neon
+     vst1.s16        d17, [r2]!
+ 
+     subs            r3, #1
+-    bne             .loop_nquant
++    bne             .Loop_nquant
+ 
+     vadd.u32        d8, d9
+     vpadd.u32       d8, d8
+@@ -2148,7 +2148,7 @@ function x265_pixel_sa8d_32x64_neon
+     mov             r10, #4
+     eor             r9, r9
+ 
+-.loop_32:
++.Loop_32:
+ 
+     sa8d_16x16 r4
+ 
+@@ -2166,7 +2166,7 @@ function x265_pixel_sa8d_32x64_neon
+     sub             r2,  r2,  #24
+ 
+     subs            r10, #1
+-    bgt            .loop_32
++    bgt            .Loop_32
+ 
+     mov             r0, r9
+     vpop            {d8-d11}
+@@ -2183,7 +2183,7 @@ function x265_pixel_sa8d_64x64_neon
+     mov             r10, #4
+     eor             r9, r9
+ 
+-.loop_1:
++.Loop_1:
+ 
+     sa8d_16x16 r4
+ 
+@@ -2217,7 +2217,7 @@ function x265_pixel_sa8d_64x64_neon
+     sub             r2,  r2,  #56
+ 
+     subs            r10, #1
+-    bgt            .loop_1
++    bgt            .Loop_1
+ 
+     mov             r0, r9
+     vpop            {d8-d11}
+diff --git a/source/common/arm/sad-a.S b/source/common/arm/sad-a.S
+index 6faf35957..b5cbded89 100644
+--- a/source/common/arm/sad-a.S
++++ b/source/common/arm/sad-a.S
+@@ -103,7 +103,7 @@ function x265_pixel_sad_16x\h\()_neon
+     vabal.u8        q9, d5, d7
+     mov             r12, #(\h-2)/2
+ 
+-.loop_16x\h:
++.Loop_16x\h:
+ 
+     subs            r12, #1
+     vld1.8          {q0}, [r0], r1
+@@ -115,7 +115,7 @@ function x265_pixel_sad_16x\h\()_neon
+     vabal.u8        q9, d1, d3
+     vabal.u8        q8, d4, d6
+     vabal.u8        q9, d5, d7
+-    bne             .loop_16x\h
++    bne             .Loop_16x\h
+ 
+     vadd.u16        q8, q8, q9
+ .if \h == 64
+@@ -147,7 +147,7 @@ function x265_pixel_sad_32x\h\()_neon
+     veor.u8         q11, q11
+     mov             r12, #\h/8
+ 
+-.loop_32x\h:
++.Loop_32x\h:
+ 
+     subs            r12, #1
+ .rept 4
+@@ -166,7 +166,7 @@ function x265_pixel_sad_32x\h\()_neon
+     vabal.u8        q10, d26, d30
+     vabal.u8        q11, d27, d31
+ .endr
+-    bne             .loop_32x\h
++    bne             .Loop_32x\h
+ 
+     vadd.u16        q8, q8, q9
+     vadd.u16        q10, q10, q11
+@@ -213,7 +213,7 @@ function x265_pixel_sad_64x\h\()_neon
+     sub             r3, r12
+     mov             r12, #\h/8
+ 
+-.loop_64x\h:
++.Loop_64x\h:
+ 
+     subs            r12, #1
+ .rept 4
+@@ -246,7 +246,7 @@ function x265_pixel_sad_64x\h\()_neon
+     vabal.u8        q10, d26, d30
+     vabal.u8        q11, d27, d31
+ .endr
+-    bne             .loop_64x\h
++    bne             .Loop_64x\h
+ 
+     vadd.u16        q8, q8, q9
+     vadd.u16        q10, q10, q11
+@@ -283,7 +283,7 @@ function x265_pixel_sad_24x32_neon
+     sub             r3, #16
+     mov             r12, #8
+ 
+-.loop_24x32:
++.Loop_24x32:
+ 
+     subs            r12, #1
+ .rept 4
+@@ -296,7 +296,7 @@ function x265_pixel_sad_24x32_neon
+     vld1.8          {d1}, [r2], r3
+     vabal.u8        q10, d0, d1
+ .endr
+-    bne             .loop_24x32
++    bne             .Loop_24x32
+ 
+     vadd.u16        q8, q8, q9
+     vadd.u16        d16, d16, d17
+@@ -322,7 +322,7 @@ function x265_pixel_sad_48x64_neon
+     sub             r3, #32
+     mov             r12, #16
+ 
+-.loop_48x64:
++.Loop_48x64:
+ 
+     subs            r12, #1
+ .rept 4
+@@ -337,7 +337,7 @@ function x265_pixel_sad_48x64_neon
+     vabal.u8        q14, d4, d20
+     vabal.u8        q15, d5, d21
+ .endr
+-    bne             .loop_48x64
++    bne             .Loop_48x64
+ 
+     vadd.u16        q3, q3, q11
+     vadd.u16        d6, d6, d7
+@@ -635,12 +635,12 @@ function x265_sad_x\x\()_16x\h\()_neon
+     veor.u8         q15, q15
+ .endif
+ 
+-.loop_sad_x\x\()_16x\h:
++.Loop_sad_x\x\()_16x\h:
+ .rept 8
+     SAD_X_16 \x
+ .endr
+     subs            r6, #1
+-    bne             .loop_sad_x\x\()_16x\h
++    bne             .Loop_sad_x\x\()_16x\h
+ 
+     vadd.u16        q8, q8, q9
+     vadd.u16        q10, q10, q11
+@@ -929,12 +929,12 @@ function x265_sad_x\x\()_64x\h\()_neon
+     veor.u8         q14, q14
+     veor.u8         q15, q15
+ .endif
+-.loop_sad_x\x\()_64x\h:
++.Loop_sad_x\x\()_64x\h:
+ .rept 8
+     SAD_X_64 \x
+ .endr
+     subs            r6, #1
+-    bne             .loop_sad_x\x\()_64x\h
++    bne             .Loop_sad_x\x\()_64x\h
+ 
+ .if \h <= 16
+     vadd.u16        q8, q8, q9
+@@ -1071,12 +1071,12 @@ function x265_sad_x\x\()_48x64_neon
+     veor.u8         q15, q15
+ .endif
+ 
+-.loop_sad_x\x\()_48x64:
++.Loop_sad_x\x\()_48x64:
+ .rept 8
+     SAD_X_48 \x
+ .endr
+     subs            r6, #1
+-    bne             .loop_sad_x\x\()_48x64
++    bne             .Loop_sad_x\x\()_48x64
+ 
+     vpaddl.u16      q8, q8
+     vpaddl.u16      q9, q9
+@@ -1179,12 +1179,12 @@ function x265_sad_x\x\()_24x32_neon
+     veor.u8         q15, q15
+ .endif
+ 
+-.loop_sad_x\x\()_24x32:
++.Loop_sad_x\x\()_24x32:
+ .rept 8
+     SAD_X_24 \x
+ .endr
+     subs            r6, #1
+-    bne             .loop_sad_x\x\()_24x32
++    bne             .Loop_sad_x\x\()_24x32
+ 
+     vadd.u16        q8, q8, q9
+     vadd.u16        q10, q10, q11
+diff --git a/source/common/arm/ssd-a.S b/source/common/arm/ssd-a.S
+index bb91a0bcb..c00ab0023 100644
+--- a/source/common/arm/ssd-a.S
++++ b/source/common/arm/ssd-a.S
+@@ -121,7 +121,7 @@ function x265_pixel_sse_pp_32x32_neon
+     veor.u8     q0, q0
+     veor.u8     q1, q1
+ 
+-.loop_sse_pp_32:
++.Loop_sse_pp_32:
+     subs        r12, #1
+ .rept 4
+     vld1.64     {q8-q9}, [r0], r1
+@@ -139,7 +139,7 @@ function x265_pixel_sse_pp_32x32_neon
+     vmlal.s16   q0, d26, d26
+     vmlal.s16   q1, d27, d27
+ .endr
+-    bne         .loop_sse_pp_32
++    bne         .Loop_sse_pp_32
+     vadd.s32    q0, q1
+     vadd.s32    d0, d0, d1
+     vpadd.s32   d0, d0, d0
+@@ -154,7 +154,7 @@ function x265_pixel_sse_pp_64x64_neon
+     veor.u8     q0, q0
+     veor.u8     q1, q1
+ 
+-.loop_sse_pp_64:
++.Loop_sse_pp_64:
+     subs        r12, #1
+ .rept 4
+     vld1.64     {q8-q9}, [r0]!
+@@ -187,7 +187,7 @@ function x265_pixel_sse_pp_64x64_neon
+     vmlal.s16   q0, d26, d26
+     vmlal.s16   q1, d27, d27
+ .endr
+-    bne         .loop_sse_pp_64
++    bne         .Loop_sse_pp_64
+     vadd.s32    q0, q1
+     vadd.s32    d0, d0, d1
+     vpadd.s32   d0, d0, d0
+@@ -257,7 +257,7 @@ function x265_pixel_sse_ss_16x16_neon
+     veor.u8     q0, q0
+     veor.u8     q1, q1
+ 
+-.loop_sse_ss_16:
++.Loop_sse_ss_16:
+     subs        r12, #1
+ .rept 4
+     vld1.s16    {q8-q9}, [r0], r1
+@@ -269,7 +269,7 @@ function x265_pixel_sse_ss_16x16_neon
+     vmlal.s16   q0, d18, d18
+     vmlal.s16   q1, d19, d19
+ .endr
+-    bne         .loop_sse_ss_16
++    bne         .Loop_sse_ss_16
+     vadd.s32    q0, q1
+     vadd.s32    d0, d0, d1
+     vpadd.s32   d0, d0, d0
+@@ -286,7 +286,7 @@ function x265_pixel_sse_ss_32x32_neon
+     veor.u8     q0, q0
+     veor.u8     q1, q1
+ 
+-.loop_sse_ss_32:
++.Loop_sse_ss_32:
+     subs        r12, #1
+ .rept 4
+     vld1.s16    {q8-q9}, [r0]!
+@@ -307,7 +307,7 @@ function x265_pixel_sse_ss_32x32_neon
+     vmlal.s16   q0, d18, d18
+     vmlal.s16   q1, d19, d19
+ .endr
+-    bne         .loop_sse_ss_32
++    bne         .Loop_sse_ss_32
+     vadd.s32    q0, q1
+     vadd.s32    d0, d0, d1
+     vpadd.s32   d0, d0, d0
+@@ -324,7 +324,7 @@ function x265_pixel_sse_ss_64x64_neon
+     veor.u8     q0, q0
+     veor.u8     q1, q1
+ 
+-.loop_sse_ss_64:
++.Loop_sse_ss_64:
+     subs        r12, #1
+ .rept 2
+     vld1.s16    {q8-q9}, [r0]!
+@@ -363,7 +363,7 @@ function x265_pixel_sse_ss_64x64_neon
+     vmlal.s16   q0, d18, d18
+     vmlal.s16   q1, d19, d19
+ .endr
+-    bne         .loop_sse_ss_64
++    bne         .Loop_sse_ss_64
+     vadd.s32    q0, q1
+     vadd.s32    d0, d0, d1
+     vpadd.s32   d0, d0, d0
+@@ -417,7 +417,7 @@ function x265_pixel_ssd_s_16x16_neon
+     veor.u8     q0, q0
+     veor.u8     q1, q1
+ 
+-.loop_ssd_s_16:
++.Loop_ssd_s_16:
+     subs        r12, #1
+ .rept 2
+     vld1.s16    {q8-q9}, [r0], r1
+@@ -431,7 +431,7 @@ function x265_pixel_ssd_s_16x16_neon
+     vmlal.s16   q0, d22, d22
+     vmlal.s16   q1, d23, d23
+ .endr
+-    bne         .loop_ssd_s_16
++    bne         .Loop_ssd_s_16
+     vadd.s32    q0, q1
+     vadd.s32    d0, d0, d1
+     vpadd.s32   d0, d0, d0
+@@ -446,7 +446,7 @@ function x265_pixel_ssd_s_32x32_neon
+     veor.u8     q0, q0
+     veor.u8     q1, q1
+ 
+-.loop_ssd_s_32:
++.Loop_ssd_s_32:
+     subs        r12, #1
+ .rept 4
+     vld1.s16    {q8-q9}, [r0]!
+@@ -460,7 +460,7 @@ function x265_pixel_ssd_s_32x32_neon
+     vmlal.s16   q0, d22, d22
+     vmlal.s16   q1, d23, d23
+ .endr
+-    bne         .loop_ssd_s_32
++    bne         .Loop_ssd_s_32
+     vadd.s32    q0, q1
+     vadd.s32    d0, d0, d1
+     vpadd.s32   d0, d0, d0
+diff --git a/source/common/common.h b/source/common/common.h
+index 37c19ae72..43025df06 100644
+--- a/source/common/common.h
++++ b/source/common/common.h
+@@ -176,6 +176,12 @@ inline T x265_clip3(T minVal, T maxVal, T a) { return x265_min(x265_max(minVal,
+ template<typename T> /* clip to pixel range, 0..255 or 0..1023 */
+ inline pixel x265_clip(T x) { return (pixel)x265_min<T>(T((1 << X265_DEPTH) - 1), x265_max<T>(T(0), x)); }
+ 
++/* get the sign of input variable */
++static inline int8_t x265_signOf(int32_t x)
++{
++    return (x >> 31) | ((int32_t)((((uint32_t) - x)) >> 31));
++}
++
+ typedef int16_t  coeff_t;      // transform coefficient
+ 
+ #define X265_MIN(a, b) ((a) < (b) ? (a) : (b))
+diff --git a/source/common/loopfilter.cpp b/source/common/loopfilter.cpp
+index 8651390d2..f4cd65389 100644
+--- a/source/common/loopfilter.cpp
++++ b/source/common/loopfilter.cpp
+@@ -30,16 +30,10 @@
+ 
+ namespace {
+ 
+-/* get the sign of input variable (TODO: this is a dup, make common) */
+-inline int8_t signOf(int x)
+-{
+-    return (x >> 31) | ((int)((((uint32_t)-x)) >> 31));
+-}
+-
+ static void calSign(int8_t *dst, const pixel *src1, const pixel *src2, const int endX)
+ {
+     for (int x = 0; x < endX; x++)
+-        dst[x] = signOf(src1[x] - src2[x]);
++        dst[x] = x265_signOf(src1[x] - src2[x]);
+ }
+ 
+ static void processSaoCUE0(pixel * rec, int8_t * offsetEo, int width, int8_t* signLeft, intptr_t stride)
+@@ -70,7 +64,7 @@ static void processSaoCUE1(pixel* rec, int8_t* upBuff1, int8_t* offsetEo, intptr
+ 
+     for (x = 0; x < width; x++)
+     {
+-        signDown = signOf(rec[x] - rec[x + stride]);
++        signDown = x265_signOf(rec[x] - rec[x + stride]);
+         edgeType = signDown + upBuff1[x] + 2;
+         upBuff1[x] = -signDown;
+         rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);
+@@ -87,7 +81,7 @@ static void processSaoCUE1_2Rows(pixel* rec, int8_t* upBuff1, int8_t* offsetEo,
+     {
+         for (x = 0; x < width; x++)
+         {
+-            signDown = signOf(rec[x] - rec[x + stride]);
++            signDown = x265_signOf(rec[x] - rec[x + stride]);
+             edgeType = signDown + upBuff1[x] + 2;
+             upBuff1[x] = -signDown;
+             rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);
+@@ -101,7 +95,7 @@ static void processSaoCUE2(pixel * rec, int8_t * bufft, int8_t * buff1, int8_t *
+     int x;
+     for (x = 0; x < width; x++)
+     {
+-        int8_t signDown = signOf(rec[x] - rec[x + stride + 1]);
++        int8_t signDown = x265_signOf(rec[x] - rec[x + stride + 1]);
+         int edgeType = signDown + buff1[x] + 2;
+         bufft[x + 1] = -signDown;
+         rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);;
+@@ -115,7 +109,7 @@ static void processSaoCUE3(pixel *rec, int8_t *upBuff1, int8_t *offsetEo, intptr
+ 
+     for (int x = startX + 1; x < endX; x++)
+     {
+-        signDown = signOf(rec[x] - rec[x + stride]);
++        signDown = x265_signOf(rec[x] - rec[x + stride]);
+         edgeType = signDown + upBuff1[x] + 2;
+         upBuff1[x - 1] = -signDown;
+         rec[x] = x265_clip(rec[x] + offsetEo[edgeType]);
+diff --git a/source/common/pixel.cpp b/source/common/pixel.cpp
+index 3cd074cfa..06e5732bd 100644
+--- a/source/common/pixel.cpp
++++ b/source/common/pixel.cpp
+@@ -266,10 +266,6 @@ int satd4(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t s
+ {
+     int satd = 0;
+ 
+-#if ENABLE_ASSEMBLY && X265_ARCH_ARM64 && !HIGH_BIT_DEPTH
+-    pixelcmp_t satd_4x4 = x265_pixel_satd_4x4_neon;
+-#endif
+-
+     for (int row = 0; row < h; row += 4)
+         for (int col = 0; col < w; col += 4)
+             satd += satd_4x4(pix1 + row * stride_pix1 + col, stride_pix1,
+@@ -284,10 +280,6 @@ int satd8(const pixel* pix1, intptr_t stride_pix1, const pixel* pix2, intptr_t s
+ {
+     int satd = 0;
+ 
+-#if ENABLE_ASSEMBLY && X265_ARCH_ARM64 && !HIGH_BIT_DEPTH
+-    pixelcmp_t satd_8x4 = x265_pixel_satd_8x4_neon;
+-#endif
+-
+     for (int row = 0; row < h; row += 4)
+         for (int col = 0; col < w; col += 8)
+             satd += satd_8x4(pix1 + row * stride_pix1 + col, stride_pix1,
+diff --git a/source/common/primitives.cpp b/source/common/primitives.cpp
+index 10e418884..56d4319bf 100644
+--- a/source/common/primitives.cpp
++++ b/source/common/primitives.cpp
+@@ -258,8 +258,8 @@ void x265_setup_primitives(x265_param *param)
+             primitives.cu[i].intra_pred_allangs = NULL;
+ 
+ #if ENABLE_ASSEMBLY
+-#if X265_ARCH_X86
+-        setupInstrinsicPrimitives(primitives, param->cpuid);
++#if defined(X265_ARCH_X86) || defined(X265_ARCH_ARM64)
++        setupIntrinsicPrimitives(primitives, param->cpuid);
+ #endif
+         setupAssemblyPrimitives(primitives, param->cpuid);
+ #endif
+diff --git a/source/common/primitives.h b/source/common/primitives.h
+index df1cae4b7..fd343f5fe 100644
+--- a/source/common/primitives.h
++++ b/source/common/primitives.h
+@@ -470,12 +470,9 @@ inline int partitionFromLog2Size(int log2Size)
+ }
+ 
+ void setupCPrimitives(EncoderPrimitives &p);
+-void setupInstrinsicPrimitives(EncoderPrimitives &p, int cpuMask);
++void setupIntrinsicPrimitives(EncoderPrimitives &p, int cpuMask);
+ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask);
+ void setupAliasPrimitives(EncoderPrimitives &p);
+-#if X265_ARCH_ARM64
+-void setupAliasCPrimitives(EncoderPrimitives &cp, EncoderPrimitives &asmp, int cpuMask);
+-#endif
+ #if HAVE_ALTIVEC
+ void setupPixelPrimitives_altivec(EncoderPrimitives &p);
+ void setupDCTPrimitives_altivec(EncoderPrimitives &p);
+diff --git a/source/common/vec/vec-primitives.cpp b/source/common/vec/vec-primitives.cpp
+index 855ea277f..d37f7ac3d 100644
+--- a/source/common/vec/vec-primitives.cpp
++++ b/source/common/vec/vec-primitives.cpp
+@@ -59,7 +59,7 @@ void setupIntrinsicDCT_ssse3(EncoderPrimitives&);
+ void setupIntrinsicDCT_sse41(EncoderPrimitives&);
+ 
+ /* Use primitives for the best available vector architecture */
+-void setupInstrinsicPrimitives(EncoderPrimitives &p, int cpuMask)
++void setupIntrinsicPrimitives(EncoderPrimitives &p, int cpuMask)
+ {
+ #ifdef HAVE_SSE3
+     if (cpuMask & X265_CPU_SSE3)
+diff --git a/source/encoder/sao.cpp b/source/encoder/sao.cpp
+index 0c46ece53..105ec79de 100644
+--- a/source/encoder/sao.cpp
++++ b/source/encoder/sao.cpp
+@@ -36,12 +36,6 @@ inline int32_t roundIBDI(int32_t num, int32_t den)
+     return num >= 0 ? ((num * 2 + den) / (den * 2)) : -((-num * 2 + den) / (den * 2));
+ }
+ 
+-/* get the sign of input variable (TODO: this is a dup, make common) */
+-inline int8_t signOf(int x)
+-{
+-    return (x >> 31) | ((int)((((uint32_t)-x)) >> 31));
+-}
+-
+ inline int signOf2(const int a, const int b)
+ {
+     // NOTE: don't reorder below compare, both ICL, VC, GCC optimize strong depends on order!
+@@ -328,10 +322,10 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
+         {
+             for (int y = 0; y < ctuHeight; y++, rec += stride)
+             {
+-                int signLeft = signOf(rec[startX] - tmpL[y]);
++                int signLeft = x265_signOf(rec[startX] - tmpL[y]);
+                 for (int x = startX; x < endX; x++)
+                 {
+-                    int signRight = signOf(rec[x] - rec[x + 1]);
++                    int signRight = x265_signOf(rec[x] - rec[x + 1]);
+                     int edgeType = signRight + signLeft + 2;
+                     signLeft = -signRight;
+ 
+@@ -343,8 +337,8 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
+         {
+             for (int y = 0; y < ctuHeight; y += 2, rec += 2 * stride)
+             {
+-                signLeft1[0] = signOf(rec[startX] - tmpL[y]);
+-                signLeft1[1] = signOf(rec[stride + startX] - tmpL[y + 1]);
++                signLeft1[0] = x265_signOf(rec[startX] - tmpL[y]);
++                signLeft1[1] = x265_signOf(rec[stride + startX] - tmpL[y + 1]);
+ 
+                 if (!lpelx)
+                 {
+@@ -385,13 +379,13 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
+         if (ctuWidth & 15)
+         {
+             for (int x = 0; x < ctuWidth; x++)
+-                upBuff1[x] = signOf(rec[x] - tmpU[x]);
++                upBuff1[x] = x265_signOf(rec[x] - tmpU[x]);
+ 
+             for (int y = startY; y < endY; y++, rec += stride)
+             {
+                 for (int x = 0; x < ctuWidth; x++)
+                 {
+-                    int8_t signDown = signOf(rec[x] - rec[x + stride]);
++                    int8_t signDown = x265_signOf(rec[x] - rec[x + stride]);
+                     int edgeType = signDown + upBuff1[x] + 2;
+                     upBuff1[x] = -signDown;
+ 
+@@ -445,17 +439,17 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
+         else
+         {
+             for (int x = startX; x < endX; x++)
+-                upBuff1[x] = signOf(rec[x] - tmpU[x - 1]);
++                upBuff1[x] = x265_signOf(rec[x] - tmpU[x - 1]);
+         }
+ 
+         if (ctuWidth & 15)
+         {
+              for (int y = startY; y < endY; y++, rec += stride)
+              {
+-                 upBufft[startX] = signOf(rec[stride + startX] - tmpL[y]);
++                 upBufft[startX] = x265_signOf(rec[stride + startX] - tmpL[y]);
+                  for (int x = startX; x < endX; x++)
+                  {
+-                     int8_t signDown = signOf(rec[x] - rec[x + stride + 1]);
++                     int8_t signDown = x265_signOf(rec[x] - rec[x + stride + 1]);
+                      int edgeType = signDown + upBuff1[x] + 2;
+                      upBufft[x + 1] = -signDown;
+                      rec[x] = m_clipTable[rec[x] + offsetEo[edgeType]];
+@@ -468,7 +462,7 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
+         {
+             for (int y = startY; y < endY; y++, rec += stride)
+             {
+-                int8_t iSignDown2 = signOf(rec[stride + startX] - tmpL[y]);
++                int8_t iSignDown2 = x265_signOf(rec[stride + startX] - tmpL[y]);
+ 
+                 primitives.saoCuOrgE2[endX > 16](rec + startX, upBufft + startX, upBuff1 + startX, offsetEo, endX - startX, stride);
+ 
+@@ -493,25 +487,25 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
+         if (ctuWidth & 15)
+         {
+             for (int x = startX - 1; x < endX; x++)
+-                upBuff1[x] = signOf(rec[x] - tmpU[x + 1]);
++                upBuff1[x] = x265_signOf(rec[x] - tmpU[x + 1]);
+ 
+             for (int y = startY; y < endY; y++, rec += stride)
+             {
+                 int x = startX;
+-                int8_t signDown = signOf(rec[x] - tmpL[y + 1]);
++                int8_t signDown = x265_signOf(rec[x] - tmpL[y + 1]);
+                 int edgeType = signDown + upBuff1[x] + 2;
+                 upBuff1[x - 1] = -signDown;
+                 rec[x] = m_clipTable[rec[x] + offsetEo[edgeType]];
+ 
+                 for (x = startX + 1; x < endX; x++)
+                 {
+-                    signDown = signOf(rec[x] - rec[x + stride - 1]);
++                    signDown = x265_signOf(rec[x] - rec[x + stride - 1]);
+                     edgeType = signDown + upBuff1[x] + 2;
+                     upBuff1[x - 1] = -signDown;
+                     rec[x] = m_clipTable[rec[x] + offsetEo[edgeType]];
+                 }
+ 
+-                upBuff1[endX - 1] = signOf(rec[endX - 1 + stride] - rec[endX]);
++                upBuff1[endX - 1] = x265_signOf(rec[endX - 1 + stride] - rec[endX]);
+             }
+         }
+         else
+@@ -519,7 +513,7 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
+             int8_t firstSign, lastSign;
+ 
+             if (lpelx)
+-                firstSign = signOf(rec[-1] - tmpU[0]);
++                firstSign = x265_signOf(rec[-1] - tmpU[0]);
+             if (rpelx == picWidth)
+                 lastSign = upBuff1[ctuWidth - 1];
+ 
+@@ -533,14 +527,14 @@ void SAO::applyPixelOffsets(int addr, int typeIdx, int plane)
+             for (int y = startY; y < endY; y++, rec += stride)
+             {
+                 int x = startX;
+-                int8_t signDown = signOf(rec[x] - tmpL[y + 1]);
++                int8_t signDown = x265_signOf(rec[x] - tmpL[y + 1]);
+                 int edgeType = signDown + upBuff1[x] + 2;
+                 upBuff1[x - 1] = -signDown;
+                 rec[x] = m_clipTable[rec[x] + offsetEo[edgeType]];
+ 
+                 primitives.saoCuOrgE3[endX > 16](rec, upBuff1, offsetEo, stride - 1, startX, endX);
+ 
+-                upBuff1[endX - 1] = signOf(rec[endX - 1 + stride] - rec[endX]);
++                upBuff1[endX - 1] = x265_signOf(rec[endX - 1 + stride] - rec[endX]);
+             }
+         }
+ 
+@@ -1030,10 +1024,10 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
+             for (y = 0; y < ctuHeight; y++)
+             {
+                 x = (y < startY ? startX : firstX);
+-                int signLeft = signOf(rec[x] - rec[x - 1]);
++                int signLeft = x265_signOf(rec[x] - rec[x - 1]);
+                 for (; x < endX; x++)
+                 {
+-                    int signRight = signOf(rec[x] - rec[x + 1]);
++                    int signRight = x265_signOf(rec[x] - rec[x + 1]);
+                     int edgeType = signRight + signLeft + 2;
+                     signLeft = -signRight;
+ 
+@@ -1069,13 +1063,13 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
+             }
+ 
+             for (x = startX; x < ctuWidth; x++)
+-                upBuff1[x] = signOf(rec[x] - rec[x - stride]);
++                upBuff1[x] = x265_signOf(rec[x] - rec[x - stride]);
+ 
+             for (y = firstY; y < endY; y++)
+             {
+                 for (x = (y < startY - 1 ? startX : 0); x < ctuWidth; x++)
+                 {
+-                    int signDown = signOf(rec[x] - rec[x + stride]);
++                    int signDown = x265_signOf(rec[x] - rec[x + stride]);
+                     int edgeType = signDown + upBuff1[x] + 2;
+                     upBuff1[x] = -signDown;
+ 
+@@ -1117,15 +1111,15 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
+             }
+ 
+             for (x = startX; x < endX; x++)
+-                upBuff1[x] = signOf(rec[x] - rec[x - stride - 1]);
++                upBuff1[x] = x265_signOf(rec[x] - rec[x - stride - 1]);
+ 
+             for (y = firstY; y < endY; y++)
+             {
+                 x = (y < startY - 1 ? startX : firstX);
+-                upBufft[x] = signOf(rec[x + stride] - rec[x - 1]);
++                upBufft[x] = x265_signOf(rec[x + stride] - rec[x - 1]);
+                 for (; x < endX; x++)
+                 {
+-                    int signDown = signOf(rec[x] - rec[x + stride + 1]);
++                    int signDown = x265_signOf(rec[x] - rec[x + stride + 1]);
+                     int edgeType = signDown + upBuff1[x] + 2;
+                     upBufft[x + 1] = -signDown;
+ 
+@@ -1169,13 +1163,13 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
+             }
+ 
+             for (x = startX - 1; x < endX; x++)
+-                upBuff1[x] = signOf(rec[x] - rec[x - stride + 1]);
++                upBuff1[x] = x265_signOf(rec[x] - rec[x - stride + 1]);
+ 
+             for (y = firstY; y < endY; y++)
+             {
+                 for (x = (y < startY - 1 ? startX : firstX); x < endX; x++)
+                 {
+-                    int signDown = signOf(rec[x] - rec[x + stride - 1]);
++                    int signDown = x265_signOf(rec[x] - rec[x + stride - 1]);
+                     int edgeType = signDown + upBuff1[x] + 2;
+                     upBuff1[x - 1] = -signDown;
+ 
+@@ -1186,7 +1180,7 @@ void SAO::calcSaoStatsCu_BeforeDblk(Frame* frame, int idxX, int idxY)
+                     count[s_eoTable[edgeType]]++;
+                 }
+ 
+-                upBuff1[endX - 1] = signOf(rec[endX - 1 + stride] - rec[endX]);
++                upBuff1[endX - 1] = x265_signOf(rec[endX - 1 + stride] - rec[endX]);
+ 
+                 rec += stride;
+                 fenc += stride;
+@@ -1789,11 +1783,11 @@ void saoCuStatsE0_c(const int16_t *diff, const pixel *rec, intptr_t stride, int
+ 
+     for (int y = 0; y < endY; y++)
+     {
+-        int signLeft = signOf(rec[0] - rec[-1]);
++        int signLeft = x265_signOf(rec[0] - rec[-1]);
+         for (int x = 0; x < endX; x++)
+         {
+             int signRight = signOf2(rec[x], rec[x + 1]);
+-            X265_CHECK(signRight == signOf(rec[x] - rec[x + 1]), "signDown check failure\n");
++            X265_CHECK(signRight == x265_signOf(rec[x] - rec[x + 1]), "signDown check failure\n");
+             uint32_t edgeType = signRight + signLeft + 2;
+             signLeft = -signRight;
+ 
+@@ -1830,7 +1824,7 @@ void saoCuStatsE1_c(const int16_t *diff, const pixel *rec, intptr_t stride, int8
+         for (int x = 0; x < endX; x++)
+         {
+             int signDown = signOf2(rec[x], rec[x + stride]);
+-            X265_CHECK(signDown == signOf(rec[x] - rec[x + stride]), "signDown check failure\n");
++            X265_CHECK(signDown == x265_signOf(rec[x] - rec[x + stride]), "signDown check failure\n");
+             uint32_t edgeType = signDown + upBuff1[x] + 2;
+             upBuff1[x] = (int8_t)(-signDown);
+ 
+@@ -1862,11 +1856,11 @@ void saoCuStatsE2_c(const int16_t *diff, const pixel *rec, intptr_t stride, int8
+ 
+     for (int y = 0; y < endY; y++)
+     {
+-        upBufft[0] = signOf(rec[stride] - rec[-1]);
++        upBufft[0] = x265_signOf(rec[stride] - rec[-1]);
+         for (int x = 0; x < endX; x++)
+         {
+             int signDown = signOf2(rec[x], rec[x + stride + 1]);
+-            X265_CHECK(signDown == signOf(rec[x] - rec[x + stride + 1]), "signDown check failure\n");
++            X265_CHECK(signDown == x265_signOf(rec[x] - rec[x + stride + 1]), "signDown check failure\n");
+             uint32_t edgeType = signDown + upBuff1[x] + 2;
+             upBufft[x + 1] = (int8_t)(-signDown);
+             tmp_stats[edgeType] += diff[x];
+@@ -1902,7 +1896,7 @@ void saoCuStatsE3_c(const int16_t *diff, const pixel *rec, intptr_t stride, int8
+         for (int x = 0; x < endX; x++)
+         {
+             int signDown = signOf2(rec[x], rec[x + stride - 1]);
+-            X265_CHECK(signDown == signOf(rec[x] - rec[x + stride - 1]), "signDown check failure\n");
++            X265_CHECK(signDown == x265_signOf(rec[x] - rec[x + stride - 1]), "signDown check failure\n");
+             X265_CHECK(abs(upBuff1[x]) <= 1, "upBuffer1 check failure\n");
+ 
+             uint32_t edgeType = signDown + upBuff1[x] + 2;
+@@ -1911,7 +1905,7 @@ void saoCuStatsE3_c(const int16_t *diff, const pixel *rec, intptr_t stride, int8
+             tmp_count[edgeType]++;
+         }
+ 
+-        upBuff1[endX - 1] = signOf(rec[endX - 1 + stride] - rec[endX]);
++        upBuff1[endX - 1] = x265_signOf(rec[endX - 1 + stride] - rec[endX]);
+ 
+         rec += stride;
+         diff += MAX_CU_SIZE;
+diff --git a/source/test/pixelharness.cpp b/source/test/pixelharness.cpp
+index 550521666..bc255eb12 100644
+--- a/source/test/pixelharness.cpp
++++ b/source/test/pixelharness.cpp
+@@ -1373,8 +1373,7 @@ bool PixelHarness::check_saoCuStatsE1_t(saoCuStatsE1_t ref, saoCuStatsE1_t opt)
+         ref(sbuf2 + 1, pbuf3 + 1, stride, upBuff1_ref, endX, endY, stats_ref, count_ref);
+         checked(opt, sbuf2 + 1, pbuf3 + 1, stride, upBuff1_vec, endX, endY, stats_vec, count_vec);
+ 
+-        if (   memcmp(_upBuff1_ref, _upBuff1_vec, sizeof(_upBuff1_ref))
+-            || memcmp(stats_ref, stats_vec, sizeof(stats_ref))
++        if (   memcmp(stats_ref, stats_vec, sizeof(stats_ref))
+             || memcmp(count_ref, count_vec, sizeof(count_ref)))
+             return false;
+ 
+@@ -1425,10 +1424,7 @@ bool PixelHarness::check_saoCuStatsE2_t(saoCuStatsE2_t ref, saoCuStatsE2_t opt)
+         ref(sbuf2 + 1, pbuf3 + 1, stride, upBuff1_ref, upBufft_ref, endX, endY, stats_ref, count_ref);
+         checked(opt, sbuf2 + 1, pbuf3 + 1, stride, upBuff1_vec, upBufft_vec, endX, endY, stats_vec, count_vec);
+ 
+-        // TODO: don't check upBuff*, the latest output pixels different, and can move into stack temporary buffer in future
+-        if (   memcmp(_upBuff1_ref, _upBuff1_vec, sizeof(_upBuff1_ref))
+-            || memcmp(_upBufft_ref, _upBufft_vec, sizeof(_upBufft_ref))
+-            || memcmp(stats_ref, stats_vec, sizeof(stats_ref))
++        if (   memcmp(stats_ref, stats_vec, sizeof(stats_ref))
+             || memcmp(count_ref, count_vec, sizeof(count_ref)))
+             return false;
+ 
+@@ -1476,8 +1472,7 @@ bool PixelHarness::check_saoCuStatsE3_t(saoCuStatsE3_t ref, saoCuStatsE3_t opt)
+         ref(sbuf2, pbuf3, stride, upBuff1_ref, endX, endY, stats_ref, count_ref);
+         checked(opt, sbuf2, pbuf3, stride, upBuff1_vec, endX, endY, stats_vec, count_vec);
+ 
+-        if (   memcmp(_upBuff1_ref, _upBuff1_vec, sizeof(_upBuff1_ref))
+-            || memcmp(stats_ref, stats_vec, sizeof(stats_ref))
++        if (   memcmp(stats_ref, stats_vec, sizeof(stats_ref))
+             || memcmp(count_ref, count_vec, sizeof(count_ref)))
+             return false;
+ 
+diff --git a/source/test/testbench.cpp b/source/test/testbench.cpp
+index ddcfd6139..45da893a7 100644
+--- a/source/test/testbench.cpp
++++ b/source/test/testbench.cpp
+@@ -190,10 +190,10 @@ int main(int argc, char *argv[])
+         else
+             continue;
+ 
+-#if X265_ARCH_X86
++#if defined(X265_ARCH_X86) || defined(X265_ARCH_ARM64)
+         EncoderPrimitives vecprim;
+         memset(&vecprim, 0, sizeof(vecprim));
+-        setupInstrinsicPrimitives(vecprim, test_arch[i].flag);
++        setupIntrinsicPrimitives(vecprim, test_arch[i].flag);
+         setupAliasPrimitives(vecprim);
+         for (size_t h = 0; h < sizeof(harness) / sizeof(TestHarness*); h++)
+         {
+@@ -231,8 +231,8 @@ int main(int argc, char *argv[])
+ 
+     EncoderPrimitives optprim;
+     memset(&optprim, 0, sizeof(optprim));
+-#if X265_ARCH_X86
+-    setupInstrinsicPrimitives(optprim, cpuid);
++#if defined(X265_ARCH_X86) || defined(X265_ARCH_ARM64)
++    setupIntrinsicPrimitives(optprim, cpuid);
+ #endif
+ 
+     setupAssemblyPrimitives(optprim, cpuid);

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,7 +42,7 @@ case "$TARGET" in
     ;;
 esac
 
-CFLAGS="-I${PREFIX}/include -pipe -Wall -Werror=format-security -D_FORTIFY_SOURCE=2"
+CFLAGS="-I${PREFIX}/include -pipe -Wall -Werror=format-security -fPIC -D_FORTIFY_SOURCE=2"
 LDFLAGS="-L${PREFIX}/lib -pipe"
 case "$TARGET" in
   *linux*)

--- a/scripts/cc.sh
+++ b/scripts/cc.sh
@@ -334,6 +334,13 @@ fi
 
 # Compiler specific flags
 features=""
+case "${TARGET:-}" in
+  arm64* | aarch64*)
+    # Force enable i8mm for arm64, required by ffmpeg
+    features="i8mm"
+    ;;
+esac
+
 for feature in "${cpu_features[@]}"; do
   case "$CMD" in
     clang*) ;;
@@ -349,8 +356,10 @@ for feature in "${cpu_features[@]}"; do
       ;;
   esac
 
-  features="${features}+${feature}"
+  features="${features}\n${feature}"
 done
+
+features="$(printf "$features" | awk '!NF || !seen[$0]++' | xargs printf '+%s')"
 
 case "${TARGET:-}" in
   x86_64*)

--- a/scripts/cc.sh
+++ b/scripts/cc.sh
@@ -359,7 +359,9 @@ for feature in "${cpu_features[@]}"; do
   features="${features}\n${feature}"
 done
 
-features="$(printf "$features" | awk '!NF || !seen[$0]++' | xargs printf '+%s')"
+if [ -n "$features" ]; then
+  features="$(printf "$features" | awk '!NF || !seen[$0]++' | xargs -r printf '+%s')"
+fi
 
 case "${TARGET:-}" in
   x86_64*)

--- a/scripts/meson.sh
+++ b/scripts/meson.sh
@@ -10,4 +10,5 @@ exec /opt/sysroot/bin/meson setup \
   --default-library="${SHARED:-static}" \
   -Db_lto="$([ "${LTO:-1}" -eq 1 ] && echo true || echo false)" \
   -Db_staticpic=true \
+  -Db_pie=true \
   "$@"

--- a/stages/50-nvenc.sh
+++ b/stages/50-nvenc.sh
@@ -10,8 +10,9 @@ fi
 echo "Download nvenv..."
 mkdir -p nvenv
 
-# renovate: datasource=github-releases depName=FFmpeg/nv-codec-headers versioning=semver-coerced
-_tag='12.1.14.0'
+# FIX-ME: https://github.com/renovatebot/renovate/issues/27510
+# renovate: datasource=github-releases depName=FFmpeg/nv-codec-headers versioning=loose
+_tag='12.2.72.0'
 
 curl_tar "https://github.com/FFmpeg/nv-codec-headers/releases/download/n${_tag}/nv-codec-headers-${_tag}.tar.gz" nvenv 1
 

--- a/stages/50-onevpl.sh
+++ b/stages/50-onevpl.sh
@@ -10,7 +10,8 @@ esac
 echo "Download oneVPL..."
 mkdir -p oneVPL
 
-_tag='2.10.1'
+# FIX-ME: Renovate breaks due to intel using a year-based versioning scheme earlier
+_tag='2.12.0'
 
 curl_tar "https://github.com/intel/libvpl/archive/refs/tags/v${_tag}.tar.gz" oneVPL 1
 

--- a/stages/50-soxr.sh
+++ b/stages/50-soxr.sh
@@ -4,7 +4,7 @@ echo "Download soxr..."
 mkdir -p soxr
 
 # Original link: https://downloads.sourceforge.net/project/soxr/soxr-0.1.3-Source.tar.xz
-# But sourcefourge is very bad to download from, so we use the debian source instead
+# But sourceforge is very bad to download from, so we use the debian source instead
 curl_tar 'https://deb.debian.org/debian/pool/main/libs/libsoxr/libsoxr_0.1.3.orig.tar.xz' soxr 1
 
 for patch in "$PREFIX"/patches/*; do

--- a/stages/50-vpx.sh
+++ b/stages/50-vpx.sh
@@ -8,6 +8,7 @@ curl_tar 'https://gitlab.freedesktop.org/amyspark/libvpx/-/archive/0357f68/libvp
 
 # Remove xcrun tool check, because compiling for macOS don't use it and it breaks crosscompiling
 sed -i "/xcrun_exe = find_program('xcrun', required: true)/d" vpx/meson.build
+sed -i "s|supports_armv8_etc = cc.compiles|supports_armv8_etc = c.compiles|" vpx/meson.build
 
 # Remove some superfluous files
 rm -rf vpx/{third_party/googletest,build_debug,test,tools,examples,examples.mk,configure,*.dox,.gitlab*}

--- a/stages/50-vpx.sh
+++ b/stages/50-vpx.sh
@@ -3,9 +3,10 @@
 echo "Download vpx..."
 mkdir -p vpx
 
-# v1.13.1
-curl_tar 'https://gitlab.freedesktop.org/gstreamer/meson-ports/libvpx/-/archive/b2bd418/libvpx.tar.gz' vpx 1
+# v1.14.1
+curl_tar 'https://gitlab.freedesktop.org/amyspark/libvpx/-/archive/0357f68/libvpx.tar.gz' vpx 1
 
+# Remove xcrun tool check, because compiling for macOS don't use it and it breaks crosscompiling
 sed -i "/xcrun_exe = find_program('xcrun', required: true)/d" vpx/meson.build
 
 # Remove some superfluous files

--- a/stages/50-vulkan/45-vulkan.sh
+++ b/stages/50-vulkan/45-vulkan.sh
@@ -10,7 +10,7 @@ esac
 echo "Download vulkan..."
 mkdir -p vulkan-headers
 
-curl_tar 'https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.275.0.tar.gz' vulkan-headers 1
+curl_tar 'https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.283.0.tar.gz' vulkan-headers 1
 
 VERSION="$(
   sed -nr \

--- a/stages/50-vulkan/50-shaderc.sh
+++ b/stages/50-vulkan/50-shaderc.sh
@@ -12,18 +12,18 @@ mkdir -p shaderc/third_party/{glslang,spirv-headers,spirv-tools}
 
 # All the version for the main package and third-party deps must match what is here:
 # https://github.com/google/shaderc/blob/known-good/known_good.json
-curl_tar 'https://github.com/google/shaderc/archive/refs/tags/v2023.8.tar.gz' shaderc 1
+curl_tar 'https://github.com/google/shaderc/tarball/3ac03b8' shaderc 1
 
 sed -ie 's|#!/usr/bin/env python|#!/usr/bin/env python3|' shaderc/utils/update_build_version.py
 
 # Thrid party deps
-curl_tar 'https://github.com/KhronosGroup/glslang/archive/a91631b.tar.gz' shaderc/third_party/glslang 1
+curl_tar 'https://github.com/KhronosGroup/glslang/archive/fa9c3de.tar.gz' shaderc/third_party/glslang 1
 cp -a shaderc/third_party/glslang/LICENSE.txt shaderc/LICENSE.glslang
 
-curl_tar 'https://github.com/KhronosGroup/SPIRV-Headers/archive/1c6bb27.tar.gz' shaderc/third_party/spirv-headers 1
+curl_tar 'https://github.com/KhronosGroup/SPIRV-Headers/archive/2acb319.tar.gz' shaderc/third_party/spirv-headers 1
 cp -a shaderc/third_party/spirv-headers/LICENSE shaderc/LICENSE.spirv-headers
 
-curl_tar 'https://github.com/KhronosGroup/SPIRV-Tools/archive/f0cc85e.tar.gz' shaderc/third_party/spirv-tools 1
+curl_tar 'https://github.com/KhronosGroup/SPIRV-Tools/archive/0cfe9e7.tar.gz' shaderc/third_party/spirv-tools 1
 cp -a shaderc/third_party/spirv-tools/LICENSE shaderc/LICENSE.spirv-tools
 
 sed -i '/add_subdirectory(test)/d' shaderc/third_party/spirv-tools/CMakeLists.txt

--- a/stages/50-vulkan/55-spirv-cross.sh
+++ b/stages/50-vulkan/55-spirv-cross.sh
@@ -10,7 +10,7 @@ esac
 echo "Download spirv..."
 mkdir -p spirv
 
-curl_tar 'https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.3.275.0.tar.gz' spirv 1
+curl_tar 'https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.3.283.0.tar.gz' spirv 1
 
 VERSION="$(
   grep -Po 'set\(spirv-cross-abi-major\s+\K\d+' spirv/CMakeLists.txt

--- a/stages/50-vulkan/60-placebo.sh
+++ b/stages/50-vulkan/60-placebo.sh
@@ -10,12 +10,12 @@ esac
 echo "Download placebo..."
 mkdir -p placebo
 
-curl_tar 'https://github.com/haasn/libplacebo/archive/refs/tags/v6.338.2.tar.gz' placebo 1
+curl_tar 'https://github.com/haasn/libplacebo/archive/refs/tags/v7.349.0.tar.gz' placebo 1
 
 # Third party deps
-curl_tar 'https://github.com/pallets/jinja/archive/refs/tags/3.1.3.tar.gz' placebo/3rdparty/jinja 1
+curl_tar 'https://github.com/pallets/jinja/archive/refs/tags/3.1.4.tar.gz' placebo/3rdparty/jinja 1
 curl_tar 'https://github.com/pallets/markupsafe/archive/refs/tags/2.1.5.tar.gz' placebo/3rdparty/markupsafe 1
-curl_tar 'https://github.com/fastfloat/fast_float/archive/refs/tags/v6.1.0.tar.gz' placebo/3rdparty/fast_float 1
+curl_tar 'https://github.com/fastfloat/fast_float/archive/refs/tags/v6.1.1.tar.gz' placebo/3rdparty/fast_float 1
 
 sed -i "s|windows.compile_resources(libplacebo_rc, depends: version_h,|windows.compile_resources(libplacebo_rc, depends: version_h, args: '/c65001',|" placebo/src/meson.build
 

--- a/stages/50-x265.sh
+++ b/stages/50-x265.sh
@@ -23,7 +23,7 @@ done
 
 # Local patches
 for patch in "$PREFIX"/patches/*; do
-  patch -F5 -lp1 -d soxr -t <"$patch"
+  patch -F5 -lp1 -d x265 -t <"$patch"
 done
 
 # Backup source

--- a/stages/50-x265.sh
+++ b/stages/50-x265.sh
@@ -3,11 +3,13 @@
 echo "Download x265..."
 mkdir -p x265
 
-# renovate: depName=https://bitbucket.org/multicoreware/x265_git.git
-_commit='8787e87020d77416f0ff0b7f3c97ac8b90332c31'
+# renovate: datasource=bitbucket-tags depName=multicoreware/x265_git versioning=semver-coerced
+_tag='3.6'
 
 # Need to use master, because the latest release doesn't support optmized aarch64 and it is from 2021
-curl_tar "https://bitbucket.org/multicoreware/x265_git/get/${_commit}.tar.bz2" x265 1
+curl_tar "https://bitbucket.org/multicoreware/x265_git/get/${_tag}.tar.gz" x265 1
+
+#  82ff02e  ad1a30a
 
 # Remove some superfluous files
 rm -rf x265/{doc,build}
@@ -17,6 +19,11 @@ for patch in \
   'https://github.com/HandBrake/HandBrake/raw/9c9cf41/contrib/x265/A03-sei-length-crash-fix.patch' \
   'https://github.com/HandBrake/HandBrake/raw/9c9cf41/contrib/x265/A05-memory-leaks.patch'; do
   curl "$patch" | patch -F5 -lp1 -d x265 -t
+done
+
+# Local patches
+for patch in "$PREFIX"/patches/*; do
+  patch -F5 -lp1 -d soxr -t <"$patch"
 done
 
 # Backup source

--- a/stages/99-ffmpeg.sh
+++ b/stages/99-ffmpeg.sh
@@ -226,6 +226,7 @@ if ! ./configure \
   --enable-lzma \
   --enable-opencl \
   --enable-optimizations \
+  --enable-pic \
   --enable-postproc \
   --enable-shared \
   --enable-swscale \

--- a/stages/99-ffmpeg.sh
+++ b/stages/99-ffmpeg.sh
@@ -3,31 +3,29 @@
 echo "Download ffmpeg..."
 mkdir -p ffmpeg
 
-curl_tar 'https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n6.1.1.tar.gz' ffmpeg 1
+curl_tar 'https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n7.0.1.tar.gz' ffmpeg 1
 
 # Handbreak patches
 for patch in \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A01-mov-read-name-track-tag-written-by-movenc.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A02-movenc-write-3gpp-track-titl-tag.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A03-mov-read-3gpp-udta-tags.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A04-movenc-write-3gpp-track-names-tags-for-all-available.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A05-dvdsubdec-fix-processing-of-partial-packets.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A06-dvdsubdec-return-number-of-bytes-used.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A07-dvdsubdec-use-pts-of-initial-packet.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A08-ccaption_dec-fix-pts-in-real_time-mode.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A09-matroskaenc-aac-extradata-updated.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A10-amfenc-Add-support-for-pict_type-field.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A11-amfenc-Fixes-the-color-information-in-the-ou.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A12-amfenc-HDR-metadata.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A13-libavcodec-amfenc-Fix-issue-with-missing-headers-in-.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A14-avcodec-add-ambient-viewing-environment-packet-side-.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A15-avformat-mov-add-support-for-amve-ambient-viewing-en.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A16-videotoolbox-dec-h264.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A17-libswscale-fix-yuv420p-to-p01xle-color-conversion-bu.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A18-qsv-fix-decode-10bit-hdr.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A19-ffbuild-common-use-gzip-n-flag-for-cuda.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A20-vf_scale_preserve_range.patch' \
-  'https://github.com/HandBrake/HandBrake/raw/5c81a46/contrib/ffmpeg/A21-dvdsubdec-do-not-discard-zero-sized-rects.patch'; do
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A01-mov-read-name-track-tag-written-by-movenc.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A02-movenc-write-3gpp-track-titl-tag.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A03-mov-read-3gpp-udta-tags.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A04-movenc-write-3gpp-track-names-tags-for-all-available.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A05-dvdsubdec-fix-processing-of-partial-packets.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A06-dvdsubdec-return-number-of-bytes-used.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A07-dvdsubdec-use-pts-of-initial-packet.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A08-dvdsubdec-do-not-discard-zero-sized-rects.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A09-ccaption_dec-fix-pts-in-real_time-mode.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A10-matroskaenc-aac-extradata-updated.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A11-videotoolbox-disable-H.264-10-bit-on-Intel-macOS.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A12-libswscale-fix-yuv420p-to-p01xle-color-conversion-bu.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A13-qsv-fix-decode-10bit-hdr.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A14-amfenc-Add-support-for-pict_type-field.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A15-amfenc-Fixes-the-color-information-in-the-ou.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A16-amfenc-HDR-metadata.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A17-av1dec-dovi-rpu.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A18-avformat-mov-add-support-audio-fallback-track-ref.patch' \
+  'https://github.com/HandBrake/HandBrake/raw/0cc92fb/contrib/ffmpeg/A19-fix-qsv-on-gcc-14.patch'; do
   curl "$patch" | patch -F5 -lp1 -d ffmpeg -t
 done
 
@@ -72,8 +70,6 @@ case "$TARGET" in
       --x86asmexe=false
       --enable-vfp
       --enable-neon
-      # Our baseline ARM platform for Linux and Windows is raspberry pi 3 which doesn't support i8mm
-      --disable-i8mm
     )
     ;;
 esac
@@ -100,6 +96,7 @@ case "$TARGET" in
     ;;
   *linux*)
     env_specific_arg+=(
+      --disable-libdrm
       --disable-coreimage
       --disable-w32threads
       --disable-videotoolbox


### PR DESCRIPTION
 - Update ffmpeg to v7.0.1
   - Update Handbreak patches for ffmpeg
 - Use x265 latest stable version instead of git HEAD
 - Backport some newer x265 aarch64 improvements as a patch
 - Update nvenv to 12.2.72.0 
   - Renovate is not working for this dep. Probably related to this issue: https://github.com/renovatebot/renovate/issues/27510
 - Update OneVPL to 2.12.0
 - Update vpx to 1.14.1
 - Update Vulkan sdk to 1.3.283.0
 - Update shaderc to 2024.2
 - Update libplacebo to v7.349.0