### PR TITLE
Revert from fork to oficial gstreamer meson-port of libvpx

### DIFF
--- a/stages/50-vpx.sh
+++ b/stages/50-vpx.sh
@@ -3,8 +3,10 @@
 echo "Download vpx..."
 mkdir -p vpx
 
-# v1.14.1
-curl_tar 'https://gitlab.freedesktop.org/amyspark/libvpx/-/archive/8260fdd/libvpx.tar.gz' vpx 1
+# renovate: depName=https://gitlab.freedesktop.org/gstreamer/meson-ports/libvpx.git
+_commit="31fdd5dd78347b2468d8a3c4a946f21d230cf19b"
+
+curl_tar "https://gitlab.freedesktop.org/gstreamer/meson-ports/libvpx/-/archive/${_commit}/libvpx.tar.gz" vpx 1
 
 # Delete lines related to xcrun tool usage, it is irrelevant for us
 sed -i '1183,1189d' vpx/meson.build


### PR DESCRIPTION
PR for v1.14.1 was merged:
https://gitlab.freedesktop.org/gstreamer/meson-ports/libvpx/-/merge_requests/21