### PR TITLE
Disable `vaMapBuffer2` usage in FFmpeg due to incompatibilities with Ubuntu

### DIFF
--- a/patches/99-ffmpeg/use-vaMapBuffer2-for-mapping-image.patch
+++ b/patches/99-ffmpeg/use-vaMapBuffer2-for-mapping-image.patch
@@ -1,0 +1,43 @@
+From 1e2ac489a475198460e424fd4a3d166bb3f424a4 Mon Sep 17 00:00:00 2001
+From: David Rosca <nowrep@gmail.com>
+Date: Fri, 27 Oct 2023 22:25:50 +0200
+Subject: [PATCH] lavu/hwcontext_vaapi: Use vaMapBuffer2 for mapping image
+ buffers
+
+This allows some optimizations in driver, such as not having to read
+back the data if write-only mapping is requested.
+---
+ libavutil/hwcontext_vaapi.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/libavutil/hwcontext_vaapi.c b/libavutil/hwcontext_vaapi.c
+index 56d03aa4cdd3a..4cb25dd03212e 100644
+--- a/libavutil/hwcontext_vaapi.c
++++ b/libavutil/hwcontext_vaapi.c
+@@ -809,6 +809,9 @@ static int vaapi_map_frame(AVHWFramesContext *hwfc,
+     VAStatus vas;
+     void *address = NULL;
+     int err, i;
++#if VA_CHECK_VERSION(1, 21, 0)
++    uint32_t vaflags = 0;
++#endif
+ 
+     surface_id = (VASurfaceID)(uintptr_t)src->data[3];
+     av_log(hwfc, AV_LOG_DEBUG, "Map surface %#x.\n", surface_id);
+@@ -892,7 +895,16 @@ static int vaapi_map_frame(AVHWFramesContext *hwfc,
+         }
+     }
+ 
++#if VA_CHECK_VERSION(1, 21, 0)
++    if (flags & AV_HWFRAME_MAP_READ)
++        vaflags |= VA_MAPBUFFER_FLAG_READ;
++    if (flags & AV_HWFRAME_MAP_WRITE)
++        vaflags |= VA_MAPBUFFER_FLAG_WRITE;
++    // On drivers not implementing vaMapBuffer2 libva calls vaMapBuffer instead.
++    vas = vaMapBuffer2(hwctx->display, map->image.buf, &address, vaflags);
++#else
+     vas = vaMapBuffer(hwctx->display, map->image.buf, &address);
++#endif
+     if (vas != VA_STATUS_SUCCESS) {
+         av_log(hwfc, AV_LOG_ERROR, "Failed to map image from surface "
+                "%#x: %d (%s).\n", surface_id, vas, vaErrorStr(vas));

--- a/stages/99-ffmpeg.sh
+++ b/stages/99-ffmpeg.sh
@@ -3,8 +3,7 @@
 echo "Download ffmpeg..."
 mkdir -p ffmpeg
 
-# Can't upgrade to 7.1 due to issues with libvautil on any Ubuntu version under the latest in-dev version, due to usage of vaMapBuffer2
-curl_tar 'https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n7.0.2.tar.gz' ffmpeg 1
+curl_tar 'https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n7.1.tar.gz' ffmpeg 1
 
 # Handbreak patches
 for patch in \
@@ -36,6 +35,14 @@ if [ "$OS_IPHONE" -gt 0 ]; then
   # Patch to remove ffmpeg using non public API on iOS
   patch -F5 -lp1 -d ffmpeg -t <"$PREFIX"/patches/remove_lzma_apple_non_public_api.patch
 fi
+
+case "$TARGET" in
+  *linux*)
+    # Remove the usage of vaMapBuffer2 for mapping image due to incompatible with older libva
+    # https://github.com/BtbN/FFmpeg-Builds/issues/457
+    patch -R -F5 -lp1 -d ffmpeg -t <"$PREFIX"/patches/use-vaMapBuffer2-for-mapping-image.patch
+    ;;
+esac
 
 # Backup source
 bak_src 'ffmpeg'


### PR DESCRIPTION
 - Revert FFmpeg to version 7.1
 - Reverse patch adding `vaMapBuffer2` support to FFmpeg due to incompatibilities with the libva version available on Ubuntu: https://github.com/BtbN/FFmpeg-Builds/issues/457